### PR TITLE
Install PHP zip extension by default

### DIFF
--- a/apache-php7/Dockerfile
+++ b/apache-php7/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libmcrypt-dev 
 	&& docker-php-ext-install gd
 RUN docker-php-ext-install mysqli
 RUN docker-php-ext-install mcrypt
+RUN docker-php-ext-install zip
 
 VOLUME /var/www/html
 

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libmcrypt-dev 
 	&& docker-php-ext-install gd
 RUN docker-php-ext-install mysqli
 RUN docker-php-ext-install mcrypt
+RUN docker-php-ext-install zip
 
 VOLUME /var/www/html
 

--- a/fpm-php7/Dockerfile
+++ b/fpm-php7/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libmcrypt-dev 
 	&& docker-php-ext-install gd
 RUN docker-php-ext-install mysqli
 RUN docker-php-ext-install mcrypt
+RUN docker-php-ext-install zip
 
 VOLUME /var/www/html
 

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libmcrypt-dev 
 	&& docker-php-ext-install gd
 RUN docker-php-ext-install mysqli
 RUN docker-php-ext-install mcrypt
+RUN docker-php-ext-install zip
 
 VOLUME /var/www/html
 


### PR DESCRIPTION
Joomla! recommends installing native zip support by default. Build and install the extension.