### PR TITLE
Allows for empty mysql root passwords as requested in issue #23

### DIFF
--- a/apache-php7/docker-entrypoint.sh
+++ b/apache-php7/docker-entrypoint.sh
@@ -22,7 +22,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 
         # If the DB user is 'root' then use the MySQL root password env var
         : ${JOOMLA_DB_USER:=root}
-        if [ "$JOOMLA_DB_USER" = 'root' ] && [ "$JOOMLA_DB_PASSWORD_ALLOW_EMPTY" != 'yes' ]; then
+        if [ "$JOOMLA_DB_USER" = 'root' ]; then
                 : ${JOOMLA_DB_PASSWORD:=$MYSQL_ENV_MYSQL_ROOT_PASSWORD}
         fi
         : ${JOOMLA_DB_NAME:=joomla}

--- a/apache-php7/docker-entrypoint.sh
+++ b/apache-php7/docker-entrypoint.sh
@@ -22,12 +22,12 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 
         # If the DB user is 'root' then use the MySQL root password env var
         : ${JOOMLA_DB_USER:=root}
-        if [ "$JOOMLA_DB_USER" = 'root' ]; then
+        if [ "$JOOMLA_DB_USER" = 'root' ] && [ "$JOOMLA_DB_PASSWORD_ALLOW_EMPTY" != 'yes' ]; then
                 : ${JOOMLA_DB_PASSWORD:=$MYSQL_ENV_MYSQL_ROOT_PASSWORD}
         fi
         : ${JOOMLA_DB_NAME:=joomla}
 
-        if [ -z "$JOOMLA_DB_PASSWORD" ]; then
+        if [ -z "$JOOMLA_DB_PASSWORD" ] && [ "$JOOMLA_DB_PASSWORD_ALLOW_EMPTY" != 'yes' ]; then
                 echo >&2 "error: missing required JOOMLA_DB_PASSWORD environment variable"
                 echo >&2 "  Did you forget to -e JOOMLA_DB_PASSWORD=... ?"
                 echo >&2

--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -22,7 +22,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 
         # If the DB user is 'root' then use the MySQL root password env var
         : ${JOOMLA_DB_USER:=root}
-        if [ "$JOOMLA_DB_USER" = 'root' ] && [ "$JOOMLA_DB_PASSWORD_ALLOW_EMPTY" != 'yes' ]; then
+        if [ "$JOOMLA_DB_USER" = 'root' ]; then
                 : ${JOOMLA_DB_PASSWORD:=$MYSQL_ENV_MYSQL_ROOT_PASSWORD}
         fi
         : ${JOOMLA_DB_NAME:=joomla}

--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -22,12 +22,12 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 
         # If the DB user is 'root' then use the MySQL root password env var
         : ${JOOMLA_DB_USER:=root}
-        if [ "$JOOMLA_DB_USER" = 'root' ]; then
+        if [ "$JOOMLA_DB_USER" = 'root' ] && [ "$JOOMLA_DB_PASSWORD_ALLOW_EMPTY" != 'yes' ]; then
                 : ${JOOMLA_DB_PASSWORD:=$MYSQL_ENV_MYSQL_ROOT_PASSWORD}
         fi
         : ${JOOMLA_DB_NAME:=joomla}
 
-        if [ -z "$JOOMLA_DB_PASSWORD" ]; then
+        if [ -z "$JOOMLA_DB_PASSWORD" ] && [ "$JOOMLA_DB_PASSWORD_ALLOW_EMPTY" != 'yes' ]; then
                 echo >&2 "error: missing required JOOMLA_DB_PASSWORD environment variable"
                 echo >&2 "  Did you forget to -e JOOMLA_DB_PASSWORD=... ?"
                 echo >&2

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -22,7 +22,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 
         # If the DB user is 'root' then use the MySQL root password env var
         : ${JOOMLA_DB_USER:=root}
-        if [ "$JOOMLA_DB_USER" = 'root' ] && [ "$JOOMLA_DB_PASSWORD_ALLOW_EMPTY" != 'yes' ]; then
+        if [ "$JOOMLA_DB_USER" = 'root' ]; then
                 : ${JOOMLA_DB_PASSWORD:=$MYSQL_ENV_MYSQL_ROOT_PASSWORD}
         fi
         : ${JOOMLA_DB_NAME:=joomla}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -22,12 +22,12 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 
         # If the DB user is 'root' then use the MySQL root password env var
         : ${JOOMLA_DB_USER:=root}
-        if [ "$JOOMLA_DB_USER" = 'root' ]; then
+        if [ "$JOOMLA_DB_USER" = 'root' ] && [ "$JOOMLA_DB_PASSWORD_ALLOW_EMPTY" != 'yes' ]; then
                 : ${JOOMLA_DB_PASSWORD:=$MYSQL_ENV_MYSQL_ROOT_PASSWORD}
         fi
         : ${JOOMLA_DB_NAME:=joomla}
 
-        if [ -z "$JOOMLA_DB_PASSWORD" ]; then
+        if [ -z "$JOOMLA_DB_PASSWORD" ] && [ "$JOOMLA_DB_PASSWORD_ALLOW_EMPTY" != 'yes' ]; then
                 echo >&2 "error: missing required JOOMLA_DB_PASSWORD environment variable"
                 echo >&2 "  Did you forget to -e JOOMLA_DB_PASSWORD=... ?"
                 echo >&2

--- a/fpm-php7/docker-entrypoint.sh
+++ b/fpm-php7/docker-entrypoint.sh
@@ -22,7 +22,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 
         # If the DB user is 'root' then use the MySQL root password env var
         : ${JOOMLA_DB_USER:=root}
-        if [ "$JOOMLA_DB_USER" = 'root' ] && [ "$JOOMLA_DB_PASSWORD_ALLOW_EMPTY" != 'yes' ]; then
+        if [ "$JOOMLA_DB_USER" = 'root' ]; then
                 : ${JOOMLA_DB_PASSWORD:=$MYSQL_ENV_MYSQL_ROOT_PASSWORD}
         fi
         : ${JOOMLA_DB_NAME:=joomla}

--- a/fpm-php7/docker-entrypoint.sh
+++ b/fpm-php7/docker-entrypoint.sh
@@ -22,12 +22,12 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 
         # If the DB user is 'root' then use the MySQL root password env var
         : ${JOOMLA_DB_USER:=root}
-        if [ "$JOOMLA_DB_USER" = 'root' ]; then
+        if [ "$JOOMLA_DB_USER" = 'root' ] && [ "$JOOMLA_DB_PASSWORD_ALLOW_EMPTY" != 'yes' ]; then
                 : ${JOOMLA_DB_PASSWORD:=$MYSQL_ENV_MYSQL_ROOT_PASSWORD}
         fi
         : ${JOOMLA_DB_NAME:=joomla}
 
-        if [ -z "$JOOMLA_DB_PASSWORD" ]; then
+        if [ -z "$JOOMLA_DB_PASSWORD" ] && [ "$JOOMLA_DB_PASSWORD_ALLOW_EMPTY" != 'yes' ]; then
                 echo >&2 "error: missing required JOOMLA_DB_PASSWORD environment variable"
                 echo >&2 "  Did you forget to -e JOOMLA_DB_PASSWORD=... ?"
                 echo >&2

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -22,7 +22,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 
         # If the DB user is 'root' then use the MySQL root password env var
         : ${JOOMLA_DB_USER:=root}
-        if [ "$JOOMLA_DB_USER" = 'root' ] && [ "$JOOMLA_DB_PASSWORD_ALLOW_EMPTY" != 'yes' ]; then
+        if [ "$JOOMLA_DB_USER" = 'root' ]; then
                 : ${JOOMLA_DB_PASSWORD:=$MYSQL_ENV_MYSQL_ROOT_PASSWORD}
         fi
         : ${JOOMLA_DB_NAME:=joomla}

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -22,12 +22,12 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 
         # If the DB user is 'root' then use the MySQL root password env var
         : ${JOOMLA_DB_USER:=root}
-        if [ "$JOOMLA_DB_USER" = 'root' ]; then
+        if [ "$JOOMLA_DB_USER" = 'root' ] && [ "$JOOMLA_DB_PASSWORD_ALLOW_EMPTY" != 'yes' ]; then
                 : ${JOOMLA_DB_PASSWORD:=$MYSQL_ENV_MYSQL_ROOT_PASSWORD}
         fi
         : ${JOOMLA_DB_NAME:=joomla}
 
-        if [ -z "$JOOMLA_DB_PASSWORD" ]; then
+        if [ -z "$JOOMLA_DB_PASSWORD" ] && [ "$JOOMLA_DB_PASSWORD_ALLOW_EMPTY" != 'yes' ]; then
                 echo >&2 "error: missing required JOOMLA_DB_PASSWORD environment variable"
                 echo >&2 "  Did you forget to -e JOOMLA_DB_PASSWORD=... ?"
                 echo >&2


### PR DESCRIPTION
Allows for empty mysql root passwords as requested in https://github.com/joomla/docker-joomla/issues/23.

Just omit the `JOOMLA_DB_PASSWORD` environment variable and instead add `JOOMLA_DB_PASSWORD_ALLOW_EMPTY=yes`.