### PR TITLE
Adapt installation check to Joomla v3.8.x

### DIFF
--- a/apache-php7/docker-entrypoint.sh
+++ b/apache-php7/docker-entrypoint.sh
@@ -35,7 +35,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
                 exit 1
         fi
 
-        if ! [ -e index.php -a -e libraries/cms/version/version.php ]; then
+        if ! [ -e index.php -a \( -e libraries/cms/version/version.php -o -e libraries/src/Version.php \) ]; then
                 echo >&2 "Joomla not found in $(pwd) - copying now..."
 
                 if [ "$(ls -A)" ]; then

--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -35,7 +35,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
                 exit 1
         fi
 
-        if ! [ -e index.php -a -e libraries/cms/version/version.php ]; then
+        if ! [ -e index.php -a \( -e libraries/cms/version/version.php -o -e libraries/src/Version.php \) ]; then
                 echo >&2 "Joomla not found in $(pwd) - copying now..."
 
                 if [ "$(ls -A)" ]; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -35,7 +35,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
                 exit 1
         fi
 
-        if ! [ -e index.php -a -e libraries/cms/version/version.php ]; then
+        if ! [ -e index.php -a \( -e libraries/cms/version/version.php -o -e libraries/src/Version.php \) ]; then
                 echo >&2 "Joomla not found in $(pwd) - copying now..."
 
                 if [ "$(ls -A)" ]; then

--- a/fpm-php7/docker-entrypoint.sh
+++ b/fpm-php7/docker-entrypoint.sh
@@ -35,7 +35,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
                 exit 1
         fi
 
-        if ! [ -e index.php -a -e libraries/cms/version/version.php ]; then
+        if ! [ -e index.php -a \( -e libraries/cms/version/version.php -o -e libraries/src/Version.php \) ]; then
                 echo >&2 "Joomla not found in $(pwd) - copying now..."
 
                 if [ "$(ls -A)" ]; then

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -35,7 +35,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
                 exit 1
         fi
 
-        if ! [ -e index.php -a -e libraries/cms/version/version.php ]; then
+        if ! [ -e index.php -a \( -e libraries/cms/version/version.php -o -e libraries/src/Version.php \) ]; then
                 echo >&2 "Joomla not found in $(pwd) - copying now..."
 
                 if [ "$(ls -A)" ]; then


### PR DESCRIPTION
docker-entrypoint.sh is adapted to Joomla version 3.8.x

In v3.8 the `version.php` file was moved to **`libraries/src/Version.php`**
With this change, the docker image also recognizes a previous Joomla v3.8 installation.

See issue #35