### PR TITLE
replace deprecated MAINTAINER instruction

### DIFF
--- a/apache-php7/Dockerfile
+++ b/apache-php7/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:7.0-apache
-MAINTAINER Michael Babker <michael.babker@joomla.org> (@mbabker)
+LABEL maintainer="Michael Babker <michael.babker@joomla.org> (@mbabker)"
 
 # Disable remote database security requirements.
 ENV JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK=1

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:5.6-apache
-MAINTAINER Michael Babker <michael.babker@joomla.org> (@mbabker)
+LABEL maintainer="Michael Babker <michael.babker@joomla.org> (@mbabker)"
 
 # Disable remote database security requirements.
 ENV JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK=1

--- a/fpm-php7/Dockerfile
+++ b/fpm-php7/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:7.0-fpm
-MAINTAINER Michael Babker <michael.babker@joomla.org> (@mbabker)
+LABEL maintainer="Michael Babker <michael.babker@joomla.org> (@mbabker)"
 
 # Disable remote database security requirements.
 ENV JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK=1

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:5.6-fpm
-MAINTAINER Michael Babker <michael.babker@joomla.org> (@mbabker)
+LABEL maintainer="Michael Babker <michael.babker@joomla.org> (@mbabker)"
 
 # Disable remote database security requirements.
 ENV JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK=1


### PR DESCRIPTION
The MAINTAINER instruction has been [deprecated](https://docs.docker.com/engine/reference/builder/#maintainer-deprecated). The alternative is to use LABEL.