### PR TITLE
Remove build dependencies from image

### DIFF
--- a/apache-php7.0/Dockerfile
+++ b/apache-php7.0/Dockerfile
@@ -8,25 +8,51 @@ ENV JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK=1
 RUN a2enmod rewrite
 
 # Install PHP extensions
-RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libmcrypt-dev zip unzip && rm -rf /var/lib/apt/lists/* \
-	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
-	&& docker-php-ext-install gd
-RUN docker-php-ext-install mysqli
-RUN docker-php-ext-install mcrypt
-RUN docker-php-ext-install zip
+RUN set -ex; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		libjpeg-dev \
+		libmcrypt-dev \
+		libpng12-dev \
+	; \
+	\
+	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
+	docker-php-ext-install \
+		gd \
+		mcrypt \
+		mysqli \
+		zip \
+	; \
+	\
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { print $3 }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*
 
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA1 signature
 ENV JOOMLA_VERSION 3.8.4
-ENV JOOMLA_SHA1 3d8a321e626cdf3823fc6bd62aee222fd12c19ec
+ENV JOOMLA_SHA1 9ef809f4f454d08d3fd98587c4c8aadb84e45f44
 
 # Download package and extract to web volume
-RUN curl -o joomla.zip -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.zip \
-	&& echo "$JOOMLA_SHA1 *joomla.zip" | sha1sum -c - \
+RUN curl -o joomla.tar.gz -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.gz \
+	&& echo "$JOOMLA_SHA1 *joomla.tar.gz" | sha1sum -c - \
 	&& mkdir /usr/src/joomla \
-	&& unzip joomla.zip -d /usr/src/joomla \
-	&& rm joomla.zip \
+	&& tar -xzf joomla.tar.gz -C /usr/src/joomla \
+	&& rm joomla.tar.gz \
 	&& chown -R www-data:www-data /usr/src/joomla
 
 # Copy init scripts and custom .htaccess

--- a/apache-php7.1/Dockerfile
+++ b/apache-php7.1/Dockerfile
@@ -8,25 +8,51 @@ ENV JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK=1
 RUN a2enmod rewrite
 
 # Install PHP extensions
-RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libmcrypt-dev zip unzip && rm -rf /var/lib/apt/lists/* \
-	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
-	&& docker-php-ext-install gd
-RUN docker-php-ext-install mysqli
-RUN docker-php-ext-install mcrypt
-RUN docker-php-ext-install zip
+RUN set -ex; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		libjpeg-dev \
+		libmcrypt-dev \
+		libpng12-dev \
+	; \
+	\
+	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
+	docker-php-ext-install \
+		gd \
+		mcrypt \
+		mysqli \
+		zip \
+	; \
+	\
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { print $3 }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*
 
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA1 signature
 ENV JOOMLA_VERSION 3.8.4
-ENV JOOMLA_SHA1 3d8a321e626cdf3823fc6bd62aee222fd12c19ec
+ENV JOOMLA_SHA1 9ef809f4f454d08d3fd98587c4c8aadb84e45f44
 
 # Download package and extract to web volume
-RUN curl -o joomla.zip -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.zip \
-	&& echo "$JOOMLA_SHA1 *joomla.zip" | sha1sum -c - \
+RUN curl -o joomla.tar.gz -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.gz \
+	&& echo "$JOOMLA_SHA1 *joomla.tar.gz" | sha1sum -c - \
 	&& mkdir /usr/src/joomla \
-	&& unzip joomla.zip -d /usr/src/joomla \
-	&& rm joomla.zip \
+	&& tar -xzf joomla.tar.gz -C /usr/src/joomla \
+	&& rm joomla.tar.gz \
 	&& chown -R www-data:www-data /usr/src/joomla
 
 # Copy init scripts and custom .htaccess

--- a/apache-php7.2/Dockerfile
+++ b/apache-php7.2/Dockerfile
@@ -8,24 +8,49 @@ ENV JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK=1
 RUN a2enmod rewrite
 
 # Install PHP extensions
-RUN apt-get update && apt-get install -y libpng-dev libjpeg-dev zip unzip && rm -rf /var/lib/apt/lists/* \
-	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
-	&& docker-php-ext-install gd
-RUN docker-php-ext-install mysqli
-RUN docker-php-ext-install zip
+RUN set -ex; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		libjpeg-dev \
+		libpng-dev \
+	; \
+	\
+	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
+	docker-php-ext-install \
+		gd \
+		mysqli \
+		zip \
+	; \
+	\
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { print $3 }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*
 
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA1 signature
 ENV JOOMLA_VERSION 3.8.4
-ENV JOOMLA_SHA1 3d8a321e626cdf3823fc6bd62aee222fd12c19ec
+ENV JOOMLA_SHA1 9ef809f4f454d08d3fd98587c4c8aadb84e45f44
 
 # Download package and extract to web volume
-RUN curl -o joomla.zip -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.zip \
-	&& echo "$JOOMLA_SHA1 *joomla.zip" | sha1sum -c - \
+RUN curl -o joomla.tar.gz -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.gz \
+	&& echo "$JOOMLA_SHA1 *joomla.tar.gz" | sha1sum -c - \
 	&& mkdir /usr/src/joomla \
-	&& unzip joomla.zip -d /usr/src/joomla \
-	&& rm joomla.zip \
+	&& tar -xzf joomla.tar.gz -C /usr/src/joomla \
+	&& rm joomla.tar.gz \
 	&& chown -R www-data:www-data /usr/src/joomla
 
 # Copy init scripts and custom .htaccess

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -8,25 +8,51 @@ ENV JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK=1
 RUN a2enmod rewrite
 
 # Install PHP extensions
-RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libmcrypt-dev zip unzip && rm -rf /var/lib/apt/lists/* \
-	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
-	&& docker-php-ext-install gd
-RUN docker-php-ext-install mysqli
-RUN docker-php-ext-install mcrypt
-RUN docker-php-ext-install zip
+RUN set -ex; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		libjpeg-dev \
+		libmcrypt-dev \
+		libpng12-dev \
+	; \
+	\
+	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
+	docker-php-ext-install \
+		gd \
+		mcrypt \
+		mysqli \
+		zip \
+	; \
+	\
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { print $3 }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*
 
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA1 signature
 ENV JOOMLA_VERSION 3.8.4
-ENV JOOMLA_SHA1 3d8a321e626cdf3823fc6bd62aee222fd12c19ec
+ENV JOOMLA_SHA1 9ef809f4f454d08d3fd98587c4c8aadb84e45f44
 
 # Download package and extract to web volume
-RUN curl -o joomla.zip -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.zip \
-	&& echo "$JOOMLA_SHA1 *joomla.zip" | sha1sum -c - \
+RUN curl -o joomla.tar.gz -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.gz \
+	&& echo "$JOOMLA_SHA1 *joomla.tar.gz" | sha1sum -c - \
 	&& mkdir /usr/src/joomla \
-	&& unzip joomla.zip -d /usr/src/joomla \
-	&& rm joomla.zip \
+	&& tar -xzf joomla.tar.gz -C /usr/src/joomla \
+	&& rm joomla.tar.gz \
 	&& chown -R www-data:www-data /usr/src/joomla
 
 # Copy init scripts and custom .htaccess

--- a/fpm-php7.0/Dockerfile
+++ b/fpm-php7.0/Dockerfile
@@ -5,25 +5,51 @@ LABEL maintainer="Michael Babker <michael.babker@joomla.org> (@mbabker)"
 ENV JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK=1
 
 # Install PHP extensions
-RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libmcrypt-dev zip unzip && rm -rf /var/lib/apt/lists/* \
-	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
-	&& docker-php-ext-install gd
-RUN docker-php-ext-install mysqli
-RUN docker-php-ext-install mcrypt
-RUN docker-php-ext-install zip
+RUN set -ex; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		libjpeg-dev \
+		libmcrypt-dev \
+		libpng12-dev \
+	; \
+	\
+	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
+	docker-php-ext-install \
+		gd \
+		mcrypt \
+		mysqli \
+		zip \
+	; \
+	\
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { print $3 }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*
 
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA1 signature
 ENV JOOMLA_VERSION 3.8.4
-ENV JOOMLA_SHA1 3d8a321e626cdf3823fc6bd62aee222fd12c19ec
+ENV JOOMLA_SHA1 9ef809f4f454d08d3fd98587c4c8aadb84e45f44
 
 # Download package and extract to web volume
-RUN curl -o joomla.zip -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.zip \
-	&& echo "$JOOMLA_SHA1 *joomla.zip" | sha1sum -c - \
+RUN curl -o joomla.tar.gz -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.gz \
+	&& echo "$JOOMLA_SHA1 *joomla.tar.gz" | sha1sum -c - \
 	&& mkdir /usr/src/joomla \
-	&& unzip joomla.zip -d /usr/src/joomla \
-	&& rm joomla.zip \
+	&& tar -xzf joomla.tar.gz -C /usr/src/joomla \
+	&& rm joomla.tar.gz \
 	&& chown -R www-data:www-data /usr/src/joomla
 
 # Copy init scripts and custom .htaccess

--- a/fpm-php7.1/Dockerfile
+++ b/fpm-php7.1/Dockerfile
@@ -5,25 +5,51 @@ LABEL maintainer="Michael Babker <michael.babker@joomla.org> (@mbabker)"
 ENV JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK=1
 
 # Install PHP extensions
-RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libmcrypt-dev zip unzip && rm -rf /var/lib/apt/lists/* \
-	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
-	&& docker-php-ext-install gd
-RUN docker-php-ext-install mysqli
-RUN docker-php-ext-install mcrypt
-RUN docker-php-ext-install zip
+RUN set -ex; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		libjpeg-dev \
+		libmcrypt-dev \
+		libpng12-dev \
+	; \
+	\
+	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
+	docker-php-ext-install \
+		gd \
+		mcrypt \
+		mysqli \
+		zip \
+	; \
+	\
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { print $3 }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*
 
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA1 signature
 ENV JOOMLA_VERSION 3.8.4
-ENV JOOMLA_SHA1 3d8a321e626cdf3823fc6bd62aee222fd12c19ec
+ENV JOOMLA_SHA1 9ef809f4f454d08d3fd98587c4c8aadb84e45f44
 
 # Download package and extract to web volume
-RUN curl -o joomla.zip -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.zip \
-	&& echo "$JOOMLA_SHA1 *joomla.zip" | sha1sum -c - \
+RUN curl -o joomla.tar.gz -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.gz \
+	&& echo "$JOOMLA_SHA1 *joomla.tar.gz" | sha1sum -c - \
 	&& mkdir /usr/src/joomla \
-	&& unzip joomla.zip -d /usr/src/joomla \
-	&& rm joomla.zip \
+	&& tar -xzf joomla.tar.gz -C /usr/src/joomla \
+	&& rm joomla.tar.gz \
 	&& chown -R www-data:www-data /usr/src/joomla
 
 # Copy init scripts and custom .htaccess

--- a/fpm-php7.2/Dockerfile
+++ b/fpm-php7.2/Dockerfile
@@ -5,24 +5,49 @@ LABEL maintainer="Michael Babker <michael.babker@joomla.org> (@mbabker)"
 ENV JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK=1
 
 # Install PHP extensions
-RUN apt-get update && apt-get install -y libpng-dev libjpeg-dev zip unzip && rm -rf /var/lib/apt/lists/* \
-	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
-	&& docker-php-ext-install gd
-RUN docker-php-ext-install mysqli
-RUN docker-php-ext-install zip
+RUN set -ex; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		libjpeg-dev \
+		libpng-dev \
+	; \
+	\
+	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
+	docker-php-ext-install \
+		gd \
+		mysqli \
+		zip \
+	; \
+	\
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { print $3 }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*
 
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA1 signature
 ENV JOOMLA_VERSION 3.8.4
-ENV JOOMLA_SHA1 3d8a321e626cdf3823fc6bd62aee222fd12c19ec
+ENV JOOMLA_SHA1 9ef809f4f454d08d3fd98587c4c8aadb84e45f44
 
 # Download package and extract to web volume
-RUN curl -o joomla.zip -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.zip \
-	&& echo "$JOOMLA_SHA1 *joomla.zip" | sha1sum -c - \
+RUN curl -o joomla.tar.gz -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.gz \
+	&& echo "$JOOMLA_SHA1 *joomla.tar.gz" | sha1sum -c - \
 	&& mkdir /usr/src/joomla \
-	&& unzip joomla.zip -d /usr/src/joomla \
-	&& rm joomla.zip \
+	&& tar -xzf joomla.tar.gz -C /usr/src/joomla \
+	&& rm joomla.tar.gz \
 	&& chown -R www-data:www-data /usr/src/joomla
 
 # Copy init scripts and custom .htaccess

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -5,25 +5,51 @@ LABEL maintainer="Michael Babker <michael.babker@joomla.org> (@mbabker)"
 ENV JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK=1
 
 # Install PHP extensions
-RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libmcrypt-dev zip unzip && rm -rf /var/lib/apt/lists/* \
-	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
-	&& docker-php-ext-install gd
-RUN docker-php-ext-install mysqli
-RUN docker-php-ext-install mcrypt
-RUN docker-php-ext-install zip
+RUN set -ex; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		libjpeg-dev \
+		libmcrypt-dev \
+		libpng12-dev \
+	; \
+	\
+	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
+	docker-php-ext-install \
+		gd \
+		mcrypt \
+		mysqli \
+		zip \
+	; \
+	\
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { print $3 }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*
 
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA1 signature
 ENV JOOMLA_VERSION 3.8.4
-ENV JOOMLA_SHA1 3d8a321e626cdf3823fc6bd62aee222fd12c19ec
+ENV JOOMLA_SHA1 9ef809f4f454d08d3fd98587c4c8aadb84e45f44
 
 # Download package and extract to web volume
-RUN curl -o joomla.zip -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.zip \
-	&& echo "$JOOMLA_SHA1 *joomla.zip" | sha1sum -c - \
+RUN curl -o joomla.tar.gz -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.gz \
+	&& echo "$JOOMLA_SHA1 *joomla.tar.gz" | sha1sum -c - \
 	&& mkdir /usr/src/joomla \
-	&& unzip joomla.zip -d /usr/src/joomla \
-	&& rm joomla.zip \
+	&& tar -xzf joomla.tar.gz -C /usr/src/joomla \
+	&& rm joomla.tar.gz \
 	&& chown -R www-data:www-data /usr/src/joomla
 
 # Copy init scripts and custom .htaccess

--- a/update.php
+++ b/update.php
@@ -37,14 +37,14 @@ if (!isset($version))
 
 $urlVersion = str_replace('.', '-', $version);
 
-$filename = "Joomla_$version-Stable-Full_Package.zip";
+$filename = "Joomla_$version-Stable-Full_Package.tar.gz";
 
 // Fetch the SHA1 signature for the file
 $ch = curl_init();
 
 curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-curl_setopt($ch, CURLOPT_URL, "https://downloads.joomla.org/api//v1/signatures/cms/$urlVersion");
+curl_setopt($ch, CURLOPT_URL, "https://downloads.joomla.org/api/v1/signatures/cms/$urlVersion");
 
 $result = curl_exec($ch);
 
@@ -69,7 +69,7 @@ foreach ($data['files'] as $file)
 
 if (!isset($signature))
 {
-	echo 'ZIP file SHA1 signature not included in API response.' . PHP_EOL;
+	echo 'tar.gz file SHA1 signature not included in API response.' . PHP_EOL;
 
 	exit(1);
 }

--- a/update.php
+++ b/update.php
@@ -3,7 +3,6 @@
 // Fetch the current 3.x version from the downloads site API
 $ch = curl_init();
 
-curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_URL, 'https://downloads.joomla.org/api/v1/latest/cms');
 


### PR DESCRIPTION
This change is back ported from other PHP images in the official docker library.

I also changed the download archive from `zip` to `tar.gz` to get rid of the `zip` and `unzip` dependencies (`PHP ZIP` is not affected by this change).