### PR TITLE
Add missing dependencies

### DIFF
--- a/apache-php7.0/Dockerfile
+++ b/apache-php7.0/Dockerfile
@@ -14,16 +14,23 @@ RUN set -ex; \
 	\
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		libbz2-dev \
 		libjpeg-dev \
 		libmcrypt-dev \
 		libpng12-dev \
+		libpq-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
 	docker-php-ext-install \
+		bz2 \
 		gd \
 		mcrypt \
 		mysqli \
+		pdo \
+		pdo_mysql \
+		pdo_pgsql \
+		pgsql \
 		zip \
 	; \
 	\

--- a/apache-php7.0/Dockerfile
+++ b/apache-php7.0/Dockerfile
@@ -16,6 +16,7 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		libbz2-dev \
 		libjpeg-dev \
+		libldap2-dev \
 		libmcrypt-dev \
 		libmemcached-dev \
 		libpng12-dev \
@@ -23,9 +24,12 @@ RUN set -ex; \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
+	debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+	docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
 	docker-php-ext-install \
 		bz2 \
 		gd \
+		ldap \
 		mcrypt \
 		mysqli \
 		pdo \

--- a/apache-php7.0/Dockerfile
+++ b/apache-php7.0/Dockerfile
@@ -52,14 +52,14 @@ VOLUME /var/www/html
 
 # Define Joomla version and expected SHA1 signature
 ENV JOOMLA_VERSION 3.8.4
-ENV JOOMLA_SHA1 9ef809f4f454d08d3fd98587c4c8aadb84e45f44
+ENV JOOMLA_SHA1 ee95a4120323fdb0432634d2f71c9400668c0d0c
 
 # Download package and extract to web volume
-RUN curl -o joomla.tar.gz -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.gz \
-	&& echo "$JOOMLA_SHA1 *joomla.tar.gz" | sha1sum -c - \
+RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \
+	&& echo "$JOOMLA_SHA1 *joomla.tar.bz2" | sha1sum -c - \
 	&& mkdir /usr/src/joomla \
-	&& tar -xzf joomla.tar.gz -C /usr/src/joomla \
-	&& rm joomla.tar.gz \
+	&& tar -xf joomla.tar.bz2 -C /usr/src/joomla \
+	&& rm joomla.tar.bz2 \
 	&& chown -R www-data:www-data /usr/src/joomla
 
 # Copy init scripts and custom .htaccess

--- a/apache-php7.0/Dockerfile
+++ b/apache-php7.0/Dockerfile
@@ -17,6 +17,7 @@ RUN set -ex; \
 		libbz2-dev \
 		libjpeg-dev \
 		libmcrypt-dev \
+		libmemcached-dev \
 		libpng12-dev \
 		libpq-dev \
 	; \
@@ -32,6 +33,18 @@ RUN set -ex; \
 		pdo_pgsql \
 		pgsql \
 		zip \
+	; \
+	\
+	pecl install \
+		APCu-5.1.9 \
+		memcached-3.0.4 \
+		redis-3.1.6 \
+	; \
+	\
+	docker-php-ext-enable \
+		apcu \
+		memcached \
+		redis \
 	; \
 	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies

--- a/apache-php7.1/Dockerfile
+++ b/apache-php7.1/Dockerfile
@@ -14,16 +14,23 @@ RUN set -ex; \
 	\
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		libbz2-dev \
 		libjpeg-dev \
 		libmcrypt-dev \
 		libpng12-dev \
+		libpq-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
 	docker-php-ext-install \
+		bz2 \
 		gd \
 		mcrypt \
 		mysqli \
+		pdo \
+		pdo_mysql \
+		pdo_pgsql \
+		pgsql \
 		zip \
 	; \
 	\

--- a/apache-php7.1/Dockerfile
+++ b/apache-php7.1/Dockerfile
@@ -16,6 +16,7 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		libbz2-dev \
 		libjpeg-dev \
+		libldap2-dev \
 		libmcrypt-dev \
 		libmemcached-dev \
 		libpng12-dev \
@@ -23,9 +24,12 @@ RUN set -ex; \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
+	debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+	docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
 	docker-php-ext-install \
 		bz2 \
 		gd \
+		ldap \
 		mcrypt \
 		mysqli \
 		pdo \

--- a/apache-php7.1/Dockerfile
+++ b/apache-php7.1/Dockerfile
@@ -52,14 +52,14 @@ VOLUME /var/www/html
 
 # Define Joomla version and expected SHA1 signature
 ENV JOOMLA_VERSION 3.8.4
-ENV JOOMLA_SHA1 9ef809f4f454d08d3fd98587c4c8aadb84e45f44
+ENV JOOMLA_SHA1 ee95a4120323fdb0432634d2f71c9400668c0d0c
 
 # Download package and extract to web volume
-RUN curl -o joomla.tar.gz -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.gz \
-	&& echo "$JOOMLA_SHA1 *joomla.tar.gz" | sha1sum -c - \
+RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \
+	&& echo "$JOOMLA_SHA1 *joomla.tar.bz2" | sha1sum -c - \
 	&& mkdir /usr/src/joomla \
-	&& tar -xzf joomla.tar.gz -C /usr/src/joomla \
-	&& rm joomla.tar.gz \
+	&& tar -xf joomla.tar.bz2 -C /usr/src/joomla \
+	&& rm joomla.tar.bz2 \
 	&& chown -R www-data:www-data /usr/src/joomla
 
 # Copy init scripts and custom .htaccess

--- a/apache-php7.1/Dockerfile
+++ b/apache-php7.1/Dockerfile
@@ -17,6 +17,7 @@ RUN set -ex; \
 		libbz2-dev \
 		libjpeg-dev \
 		libmcrypt-dev \
+		libmemcached-dev \
 		libpng12-dev \
 		libpq-dev \
 	; \
@@ -32,6 +33,18 @@ RUN set -ex; \
 		pdo_pgsql \
 		pgsql \
 		zip \
+	; \
+	\
+	pecl install \
+		APCu-5.1.9 \
+		memcached-3.0.4 \
+		redis-3.1.6 \
+	; \
+	\
+	docker-php-ext-enable \
+		apcu \
+		memcached \
+		redis \
 	; \
 	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies

--- a/apache-php7.2/Dockerfile
+++ b/apache-php7.2/Dockerfile
@@ -16,15 +16,19 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		libbz2-dev \
 		libjpeg-dev \
+		libldap2-dev \
 		libmemcached-dev \
 		libpng-dev \
 		libpq-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
+	debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+	docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
 	docker-php-ext-install \
 		bz2 \
 		gd \
+		ldap \
 		mysqli \
 		pdo \
 		pdo_mysql \

--- a/apache-php7.2/Dockerfile
+++ b/apache-php7.2/Dockerfile
@@ -16,6 +16,7 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		libbz2-dev \
 		libjpeg-dev \
+		libmemcached-dev \
 		libpng-dev \
 		libpq-dev \
 	; \
@@ -30,6 +31,18 @@ RUN set -ex; \
 		pdo_pgsql \
 		pgsql \
 		zip \
+	; \
+	\
+	pecl install \
+		APCu-5.1.9 \
+		memcached-3.0.4 \
+		redis-3.1.6 \
+	; \
+	\
+	docker-php-ext-enable \
+		apcu \
+		memcached \
+		redis \
 	; \
 	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies

--- a/apache-php7.2/Dockerfile
+++ b/apache-php7.2/Dockerfile
@@ -50,14 +50,14 @@ VOLUME /var/www/html
 
 # Define Joomla version and expected SHA1 signature
 ENV JOOMLA_VERSION 3.8.4
-ENV JOOMLA_SHA1 9ef809f4f454d08d3fd98587c4c8aadb84e45f44
+ENV JOOMLA_SHA1 ee95a4120323fdb0432634d2f71c9400668c0d0c
 
 # Download package and extract to web volume
-RUN curl -o joomla.tar.gz -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.gz \
-	&& echo "$JOOMLA_SHA1 *joomla.tar.gz" | sha1sum -c - \
+RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \
+	&& echo "$JOOMLA_SHA1 *joomla.tar.bz2" | sha1sum -c - \
 	&& mkdir /usr/src/joomla \
-	&& tar -xzf joomla.tar.gz -C /usr/src/joomla \
-	&& rm joomla.tar.gz \
+	&& tar -xf joomla.tar.bz2 -C /usr/src/joomla \
+	&& rm joomla.tar.bz2 \
 	&& chown -R www-data:www-data /usr/src/joomla
 
 # Copy init scripts and custom .htaccess

--- a/apache-php7.2/Dockerfile
+++ b/apache-php7.2/Dockerfile
@@ -14,14 +14,21 @@ RUN set -ex; \
 	\
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		libbz2-dev \
 		libjpeg-dev \
 		libpng-dev \
+		libpq-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
 	docker-php-ext-install \
+		bz2 \
 		gd \
 		mysqli \
+		pdo \
+		pdo_mysql \
+		pdo_pgsql \
+		pgsql \
 		zip \
 	; \
 	\

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -14,16 +14,23 @@ RUN set -ex; \
 	\
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		libbz2-dev \
 		libjpeg-dev \
 		libmcrypt-dev \
 		libpng12-dev \
+		libpq-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
 	docker-php-ext-install \
+		bz2 \
 		gd \
 		mcrypt \
 		mysqli \
+		pdo \
+		pdo_mysql \
+		pdo_pgsql \
+		pgsql \
 		zip \
 	; \
 	\

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -16,6 +16,7 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		libbz2-dev \
 		libjpeg-dev \
+		libldap2-dev \
 		libmcrypt-dev \
 		libmemcached-dev \
 		libpng12-dev \
@@ -23,9 +24,12 @@ RUN set -ex; \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
+	debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+	docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
 	docker-php-ext-install \
 		bz2 \
 		gd \
+		ldap \
 		mcrypt \
 		mysqli \
 		pdo \

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -52,14 +52,14 @@ VOLUME /var/www/html
 
 # Define Joomla version and expected SHA1 signature
 ENV JOOMLA_VERSION 3.8.4
-ENV JOOMLA_SHA1 9ef809f4f454d08d3fd98587c4c8aadb84e45f44
+ENV JOOMLA_SHA1 ee95a4120323fdb0432634d2f71c9400668c0d0c
 
 # Download package and extract to web volume
-RUN curl -o joomla.tar.gz -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.gz \
-	&& echo "$JOOMLA_SHA1 *joomla.tar.gz" | sha1sum -c - \
+RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \
+	&& echo "$JOOMLA_SHA1 *joomla.tar.bz2" | sha1sum -c - \
 	&& mkdir /usr/src/joomla \
-	&& tar -xzf joomla.tar.gz -C /usr/src/joomla \
-	&& rm joomla.tar.gz \
+	&& tar -xf joomla.tar.bz2 -C /usr/src/joomla \
+	&& rm joomla.tar.bz2 \
 	&& chown -R www-data:www-data /usr/src/joomla
 
 # Copy init scripts and custom .htaccess

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -17,6 +17,7 @@ RUN set -ex; \
 		libbz2-dev \
 		libjpeg-dev \
 		libmcrypt-dev \
+		libmemcached-dev \
 		libpng12-dev \
 		libpq-dev \
 	; \
@@ -32,6 +33,18 @@ RUN set -ex; \
 		pdo_pgsql \
 		pgsql \
 		zip \
+	; \
+	\
+	pecl install \
+		APCu-4.0.11 \
+		memcached-2.2.0 \
+		redis-3.1.6 \
+	; \
+	\
+	docker-php-ext-enable \
+		apcu \
+		memcached \
+		redis \
 	; \
 	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies

--- a/fpm-php7.0/Dockerfile
+++ b/fpm-php7.0/Dockerfile
@@ -49,14 +49,14 @@ VOLUME /var/www/html
 
 # Define Joomla version and expected SHA1 signature
 ENV JOOMLA_VERSION 3.8.4
-ENV JOOMLA_SHA1 9ef809f4f454d08d3fd98587c4c8aadb84e45f44
+ENV JOOMLA_SHA1 ee95a4120323fdb0432634d2f71c9400668c0d0c
 
 # Download package and extract to web volume
-RUN curl -o joomla.tar.gz -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.gz \
-	&& echo "$JOOMLA_SHA1 *joomla.tar.gz" | sha1sum -c - \
+RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \
+	&& echo "$JOOMLA_SHA1 *joomla.tar.bz2" | sha1sum -c - \
 	&& mkdir /usr/src/joomla \
-	&& tar -xzf joomla.tar.gz -C /usr/src/joomla \
-	&& rm joomla.tar.gz \
+	&& tar -xf joomla.tar.bz2 -C /usr/src/joomla \
+	&& rm joomla.tar.bz2 \
 	&& chown -R www-data:www-data /usr/src/joomla
 
 # Copy init scripts and custom .htaccess

--- a/fpm-php7.0/Dockerfile
+++ b/fpm-php7.0/Dockerfile
@@ -14,6 +14,7 @@ RUN set -ex; \
 		libbz2-dev \
 		libjpeg-dev \
 		libmcrypt-dev \
+		libmemcached-dev \
 		libpng12-dev \
 		libpq-dev \
 	; \
@@ -29,6 +30,18 @@ RUN set -ex; \
 		pdo_pgsql \
 		pgsql \
 		zip \
+	; \
+	\
+	pecl install \
+		APCu-5.1.9 \
+		memcached-3.0.4 \
+		redis-3.1.6 \
+	; \
+	\
+	docker-php-ext-enable \
+		apcu \
+		memcached \
+		redis \
 	; \
 	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies

--- a/fpm-php7.0/Dockerfile
+++ b/fpm-php7.0/Dockerfile
@@ -11,16 +11,23 @@ RUN set -ex; \
 	\
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		libbz2-dev \
 		libjpeg-dev \
 		libmcrypt-dev \
 		libpng12-dev \
+		libpq-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
 	docker-php-ext-install \
+		bz2 \
 		gd \
 		mcrypt \
 		mysqli \
+		pdo \
+		pdo_mysql \
+		pdo_pgsql \
+		pgsql \
 		zip \
 	; \
 	\

--- a/fpm-php7.0/Dockerfile
+++ b/fpm-php7.0/Dockerfile
@@ -13,6 +13,7 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		libbz2-dev \
 		libjpeg-dev \
+		libldap2-dev \
 		libmcrypt-dev \
 		libmemcached-dev \
 		libpng12-dev \
@@ -20,9 +21,12 @@ RUN set -ex; \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
+	debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+	docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
 	docker-php-ext-install \
 		bz2 \
 		gd \
+		ldap \
 		mcrypt \
 		mysqli \
 		pdo \

--- a/fpm-php7.1/Dockerfile
+++ b/fpm-php7.1/Dockerfile
@@ -49,14 +49,14 @@ VOLUME /var/www/html
 
 # Define Joomla version and expected SHA1 signature
 ENV JOOMLA_VERSION 3.8.4
-ENV JOOMLA_SHA1 9ef809f4f454d08d3fd98587c4c8aadb84e45f44
+ENV JOOMLA_SHA1 ee95a4120323fdb0432634d2f71c9400668c0d0c
 
 # Download package and extract to web volume
-RUN curl -o joomla.tar.gz -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.gz \
-	&& echo "$JOOMLA_SHA1 *joomla.tar.gz" | sha1sum -c - \
+RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \
+	&& echo "$JOOMLA_SHA1 *joomla.tar.bz2" | sha1sum -c - \
 	&& mkdir /usr/src/joomla \
-	&& tar -xzf joomla.tar.gz -C /usr/src/joomla \
-	&& rm joomla.tar.gz \
+	&& tar -xf joomla.tar.bz2 -C /usr/src/joomla \
+	&& rm joomla.tar.bz2 \
 	&& chown -R www-data:www-data /usr/src/joomla
 
 # Copy init scripts and custom .htaccess

--- a/fpm-php7.1/Dockerfile
+++ b/fpm-php7.1/Dockerfile
@@ -14,6 +14,7 @@ RUN set -ex; \
 		libbz2-dev \
 		libjpeg-dev \
 		libmcrypt-dev \
+		libmemcached-dev \
 		libpng12-dev \
 		libpq-dev \
 	; \
@@ -29,6 +30,18 @@ RUN set -ex; \
 		pdo_pgsql \
 		pgsql \
 		zip \
+	; \
+	\
+	pecl install \
+		APCu-5.1.9 \
+		memcached-3.0.4 \
+		redis-3.1.6 \
+	; \
+	\
+	docker-php-ext-enable \
+		apcu \
+		memcached \
+		redis \
 	; \
 	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies

--- a/fpm-php7.1/Dockerfile
+++ b/fpm-php7.1/Dockerfile
@@ -11,16 +11,23 @@ RUN set -ex; \
 	\
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		libbz2-dev \
 		libjpeg-dev \
 		libmcrypt-dev \
 		libpng12-dev \
+		libpq-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
 	docker-php-ext-install \
+		bz2 \
 		gd \
 		mcrypt \
 		mysqli \
+		pdo \
+		pdo_mysql \
+		pdo_pgsql \
+		pgsql \
 		zip \
 	; \
 	\

--- a/fpm-php7.1/Dockerfile
+++ b/fpm-php7.1/Dockerfile
@@ -13,6 +13,7 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		libbz2-dev \
 		libjpeg-dev \
+		libldap2-dev \
 		libmcrypt-dev \
 		libmemcached-dev \
 		libpng12-dev \
@@ -20,9 +21,12 @@ RUN set -ex; \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
+	debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+	docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
 	docker-php-ext-install \
 		bz2 \
 		gd \
+		ldap \
 		mcrypt \
 		mysqli \
 		pdo \

--- a/fpm-php7.2/Dockerfile
+++ b/fpm-php7.2/Dockerfile
@@ -47,14 +47,14 @@ VOLUME /var/www/html
 
 # Define Joomla version and expected SHA1 signature
 ENV JOOMLA_VERSION 3.8.4
-ENV JOOMLA_SHA1 9ef809f4f454d08d3fd98587c4c8aadb84e45f44
+ENV JOOMLA_SHA1 ee95a4120323fdb0432634d2f71c9400668c0d0c
 
 # Download package and extract to web volume
-RUN curl -o joomla.tar.gz -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.gz \
-	&& echo "$JOOMLA_SHA1 *joomla.tar.gz" | sha1sum -c - \
+RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \
+	&& echo "$JOOMLA_SHA1 *joomla.tar.bz2" | sha1sum -c - \
 	&& mkdir /usr/src/joomla \
-	&& tar -xzf joomla.tar.gz -C /usr/src/joomla \
-	&& rm joomla.tar.gz \
+	&& tar -xf joomla.tar.bz2 -C /usr/src/joomla \
+	&& rm joomla.tar.bz2 \
 	&& chown -R www-data:www-data /usr/src/joomla
 
 # Copy init scripts and custom .htaccess

--- a/fpm-php7.2/Dockerfile
+++ b/fpm-php7.2/Dockerfile
@@ -13,6 +13,7 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		libbz2-dev \
 		libjpeg-dev \
+		libmemcached-dev \
 		libpng-dev \
 		libpq-dev \
 	; \
@@ -27,6 +28,18 @@ RUN set -ex; \
 		pdo_pgsql \
 		pgsql \
 		zip \
+	; \
+	\
+	pecl install \
+		APCu-5.1.9 \
+		memcached-3.0.4 \
+		redis-3.1.6 \
+	; \
+	\
+	docker-php-ext-enable \
+		apcu \
+		memcached \
+		redis \
 	; \
 	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies

--- a/fpm-php7.2/Dockerfile
+++ b/fpm-php7.2/Dockerfile
@@ -11,14 +11,21 @@ RUN set -ex; \
 	\
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		libbz2-dev \
 		libjpeg-dev \
 		libpng-dev \
+		libpq-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
 	docker-php-ext-install \
+		bz2 \
 		gd \
 		mysqli \
+		pdo \
+		pdo_mysql \
+		pdo_pgsql \
+		pgsql \
 		zip \
 	; \
 	\

--- a/fpm-php7.2/Dockerfile
+++ b/fpm-php7.2/Dockerfile
@@ -13,15 +13,19 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		libbz2-dev \
 		libjpeg-dev \
+		libldap2-dev \
 		libmemcached-dev \
 		libpng-dev \
 		libpq-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
+	debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+	docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
 	docker-php-ext-install \
 		bz2 \
 		gd \
+		ldap \
 		mysqli \
 		pdo \
 		pdo_mysql \

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -49,14 +49,14 @@ VOLUME /var/www/html
 
 # Define Joomla version and expected SHA1 signature
 ENV JOOMLA_VERSION 3.8.4
-ENV JOOMLA_SHA1 9ef809f4f454d08d3fd98587c4c8aadb84e45f44
+ENV JOOMLA_SHA1 ee95a4120323fdb0432634d2f71c9400668c0d0c
 
 # Download package and extract to web volume
-RUN curl -o joomla.tar.gz -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.gz \
-	&& echo "$JOOMLA_SHA1 *joomla.tar.gz" | sha1sum -c - \
+RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \
+	&& echo "$JOOMLA_SHA1 *joomla.tar.bz2" | sha1sum -c - \
 	&& mkdir /usr/src/joomla \
-	&& tar -xzf joomla.tar.gz -C /usr/src/joomla \
-	&& rm joomla.tar.gz \
+	&& tar -xf joomla.tar.bz2 -C /usr/src/joomla \
+	&& rm joomla.tar.bz2 \
 	&& chown -R www-data:www-data /usr/src/joomla
 
 # Copy init scripts and custom .htaccess

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -11,16 +11,23 @@ RUN set -ex; \
 	\
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		libbz2-dev \
 		libjpeg-dev \
 		libmcrypt-dev \
 		libpng12-dev \
+		libpq-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
 	docker-php-ext-install \
+		bz2 \
 		gd \
 		mcrypt \
 		mysqli \
+		pdo \
+		pdo_mysql \
+		pdo_pgsql \
+		pgsql \
 		zip \
 	; \
 	\

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -13,6 +13,7 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		libbz2-dev \
 		libjpeg-dev \
+		libldap2-dev \
 		libmcrypt-dev \
 		libmemcached-dev \
 		libpng12-dev \
@@ -20,9 +21,12 @@ RUN set -ex; \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
+	debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+	docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
 	docker-php-ext-install \
 		bz2 \
 		gd \
+		ldap \
 		mcrypt \
 		mysqli \
 		pdo \

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -14,6 +14,7 @@ RUN set -ex; \
 		libbz2-dev \
 		libjpeg-dev \
 		libmcrypt-dev \
+		libmemcached-dev \
 		libpng12-dev \
 		libpq-dev \
 	; \
@@ -29,6 +30,18 @@ RUN set -ex; \
 		pdo_pgsql \
 		pgsql \
 		zip \
+	; \
+	\
+	pecl install \
+		APCu-4.0.11 \
+		memcached-2.2.0 \
+		redis-3.1.6 \
+	; \
+	\
+	docker-php-ext-enable \
+		apcu \
+		memcached \
+		redis \
 	; \
 	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies

--- a/update.php
+++ b/update.php
@@ -36,7 +36,7 @@ if (!isset($version))
 
 $urlVersion = str_replace('.', '-', $version);
 
-$filename = "Joomla_$version-Stable-Full_Package.tar.gz";
+$filename = "Joomla_$version-Stable-Full_Package.tar.bz2";
 
 // Fetch the SHA1 signature for the file
 $ch = curl_init();
@@ -68,7 +68,7 @@ foreach ($data['files'] as $file)
 
 if (!isset($signature))
 {
-	echo 'tar.gz file SHA1 signature not included in API response.' . PHP_EOL;
+	echo 'tar.bz2 file SHA1 signature not included in API response.' . PHP_EOL;
 
 	exit(1);
 }


### PR DESCRIPTION
This adds the following dependencies:
* Bzip2 (for package uploads)
* MySQL PDO driver
* PostgreSQL driver

Note: PostgreSQL is not yet supported in `docker-entrypoint.sh` or documented.

Since Bzip2 is added anyway we can also use Bzip2 compressed packages.
I did not update them to `3.8.5` so far.

@mbabker Joomla! seems to support some more cache handlers. Is it worth to add Memcache, Memcached, Redis, APCu etc.? There are already containers for Redis and Memcached. Do you have any preference or should I add all?
Are you aware of any other extension that is required by Joomla! components?