### PR TITLE
Update to Joomla v3.8.5

### DIFF
--- a/php5.6/apache/Dockerfile
+++ b/php5.6/apache/Dockerfile
@@ -68,8 +68,8 @@ RUN set -ex; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA1 signature
-ENV JOOMLA_VERSION 3.8.4
-ENV JOOMLA_SHA1 ee95a4120323fdb0432634d2f71c9400668c0d0c
+ENV JOOMLA_VERSION 3.8.5
+ENV JOOMLA_SHA1 0445be810e5cd2f9938ec36c9e24002129aa12de
 
 # Download package and extract to web volume
 RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \

--- a/php5.6/fpm-alpine/Dockerfile
+++ b/php5.6/fpm-alpine/Dockerfile
@@ -61,8 +61,8 @@ RUN set -ex; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA1 signature
-ENV JOOMLA_VERSION 3.8.4
-ENV JOOMLA_SHA1 ee95a4120323fdb0432634d2f71c9400668c0d0c
+ENV JOOMLA_VERSION 3.8.5
+ENV JOOMLA_SHA1 0445be810e5cd2f9938ec36c9e24002129aa12de
 
 # Download package and extract to web volume
 RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \

--- a/php5.6/fpm/Dockerfile
+++ b/php5.6/fpm/Dockerfile
@@ -65,8 +65,8 @@ RUN set -ex; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA1 signature
-ENV JOOMLA_VERSION 3.8.4
-ENV JOOMLA_SHA1 ee95a4120323fdb0432634d2f71c9400668c0d0c
+ENV JOOMLA_VERSION 3.8.5
+ENV JOOMLA_SHA1 0445be810e5cd2f9938ec36c9e24002129aa12de
 
 # Download package and extract to web volume
 RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \

--- a/php7.0/apache/Dockerfile
+++ b/php7.0/apache/Dockerfile
@@ -68,8 +68,8 @@ RUN set -ex; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA1 signature
-ENV JOOMLA_VERSION 3.8.4
-ENV JOOMLA_SHA1 ee95a4120323fdb0432634d2f71c9400668c0d0c
+ENV JOOMLA_VERSION 3.8.5
+ENV JOOMLA_SHA1 0445be810e5cd2f9938ec36c9e24002129aa12de
 
 # Download package and extract to web volume
 RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \

--- a/php7.0/fpm-alpine/Dockerfile
+++ b/php7.0/fpm-alpine/Dockerfile
@@ -61,8 +61,8 @@ RUN set -ex; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA1 signature
-ENV JOOMLA_VERSION 3.8.4
-ENV JOOMLA_SHA1 ee95a4120323fdb0432634d2f71c9400668c0d0c
+ENV JOOMLA_VERSION 3.8.5
+ENV JOOMLA_SHA1 0445be810e5cd2f9938ec36c9e24002129aa12de
 
 # Download package and extract to web volume
 RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \

--- a/php7.0/fpm/Dockerfile
+++ b/php7.0/fpm/Dockerfile
@@ -65,8 +65,8 @@ RUN set -ex; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA1 signature
-ENV JOOMLA_VERSION 3.8.4
-ENV JOOMLA_SHA1 ee95a4120323fdb0432634d2f71c9400668c0d0c
+ENV JOOMLA_VERSION 3.8.5
+ENV JOOMLA_SHA1 0445be810e5cd2f9938ec36c9e24002129aa12de
 
 # Download package and extract to web volume
 RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \

--- a/php7.1/apache/Dockerfile
+++ b/php7.1/apache/Dockerfile
@@ -68,8 +68,8 @@ RUN set -ex; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA1 signature
-ENV JOOMLA_VERSION 3.8.4
-ENV JOOMLA_SHA1 ee95a4120323fdb0432634d2f71c9400668c0d0c
+ENV JOOMLA_VERSION 3.8.5
+ENV JOOMLA_SHA1 0445be810e5cd2f9938ec36c9e24002129aa12de
 
 # Download package and extract to web volume
 RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \

--- a/php7.1/fpm-alpine/Dockerfile
+++ b/php7.1/fpm-alpine/Dockerfile
@@ -61,8 +61,8 @@ RUN set -ex; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA1 signature
-ENV JOOMLA_VERSION 3.8.4
-ENV JOOMLA_SHA1 ee95a4120323fdb0432634d2f71c9400668c0d0c
+ENV JOOMLA_VERSION 3.8.5
+ENV JOOMLA_SHA1 0445be810e5cd2f9938ec36c9e24002129aa12de
 
 # Download package and extract to web volume
 RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \

--- a/php7.1/fpm/Dockerfile
+++ b/php7.1/fpm/Dockerfile
@@ -65,8 +65,8 @@ RUN set -ex; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA1 signature
-ENV JOOMLA_VERSION 3.8.4
-ENV JOOMLA_SHA1 ee95a4120323fdb0432634d2f71c9400668c0d0c
+ENV JOOMLA_VERSION 3.8.5
+ENV JOOMLA_SHA1 0445be810e5cd2f9938ec36c9e24002129aa12de
 
 # Download package and extract to web volume
 RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \

--- a/php7.2/apache/Dockerfile
+++ b/php7.2/apache/Dockerfile
@@ -66,8 +66,8 @@ RUN set -ex; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA1 signature
-ENV JOOMLA_VERSION 3.8.4
-ENV JOOMLA_SHA1 ee95a4120323fdb0432634d2f71c9400668c0d0c
+ENV JOOMLA_VERSION 3.8.5
+ENV JOOMLA_SHA1 0445be810e5cd2f9938ec36c9e24002129aa12de
 
 # Download package and extract to web volume
 RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \

--- a/php7.2/fpm-alpine/Dockerfile
+++ b/php7.2/fpm-alpine/Dockerfile
@@ -59,8 +59,8 @@ RUN set -ex; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA1 signature
-ENV JOOMLA_VERSION 3.8.4
-ENV JOOMLA_SHA1 ee95a4120323fdb0432634d2f71c9400668c0d0c
+ENV JOOMLA_VERSION 3.8.5
+ENV JOOMLA_SHA1 0445be810e5cd2f9938ec36c9e24002129aa12de
 
 # Download package and extract to web volume
 RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \

--- a/php7.2/fpm/Dockerfile
+++ b/php7.2/fpm/Dockerfile
@@ -63,8 +63,8 @@ RUN set -ex; \
 VOLUME /var/www/html
 
 # Define Joomla version and expected SHA1 signature
-ENV JOOMLA_VERSION 3.8.4
-ENV JOOMLA_SHA1 ee95a4120323fdb0432634d2f71c9400668c0d0c
+ENV JOOMLA_VERSION 3.8.5
+ENV JOOMLA_SHA1 0445be810e5cd2f9938ec36c9e24002129aa12de
 
 # Download package and extract to web volume
 RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \


### PR DESCRIPTION
Joomla Bugfix Release 3.8.5 was released [over a month ago](https://www.joomla.org/announcements/release-news/5724-joomla-3-8-5-release.html), so I ran your very own `update.php` in this repository to reflect this in the "official" Docker image, too.
