### PR TITLE
Support automatic version update via Docker

### DIFF
--- a/php5.6/apache/Dockerfile
+++ b/php5.6/apache/Dockerfile
@@ -71,7 +71,7 @@ VOLUME /var/www/html
 ENV JOOMLA_VERSION 3.8.6
 ENV JOOMLA_SHA1 769d86c00b3add41b1fa6c85f3ec823a07df88d1
 
-# Download package and extract to web volume
+# Download package and extract to intermediate directory
 RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \
 	&& echo "$JOOMLA_SHA1 *joomla.tar.bz2" | sha1sum -c - \
 	&& mkdir /usr/src/joomla \

--- a/php5.6/apache/Dockerfile
+++ b/php5.6/apache/Dockerfile
@@ -82,6 +82,7 @@ RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/dow
 # Copy init scripts and custom .htaccess
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY makedb.php /makedb.php
+COPY postupdate.php /postupdate.php
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["apache2-foreground"]

--- a/php5.6/apache/postupdate.php
+++ b/php5.6/apache/postupdate.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Post-Manual Update Script
+ *
+ * from https://gist.github.com/mbabker/d7bfb4e1e2fbc6b7815a733607f89281
+ *
+ * @package    Joomla.Administrator
+ *
+ * @copyright  Copyright (C) 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+/**
+ * Define the application's minimum supported PHP version as a constant so it can be referenced within the application.
+ */
+define('JOOMLA_MINIMUM_PHP', '5.3.10');
+
+if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<'))
+{
+	die('Your host needs to use PHP ' . JOOMLA_MINIMUM_PHP . ' or higher to run this version of Joomla!');
+}
+
+/**
+ * Constant that is checked in included files to prevent direct access.
+ * define() is used in the installation folder rather than "const" to not error for PHP 5.2 and lower
+ */
+define('_JEXEC', 1);
+
+// Load the administrator application's path constants
+if (file_exists(__DIR__ . '/defines.php'))
+{
+	include_once __DIR__ . '/defines.php';
+}
+
+if (!defined('_JDEFINES'))
+{
+	define('JPATH_BASE', __DIR__);
+	require_once JPATH_BASE . '/includes/defines.php';
+}
+
+require_once JPATH_BASE . '/includes/framework.php';
+require_once JPATH_BASE . '/includes/helper.php';
+require_once JPATH_BASE . '/includes/toolbar.php';
+
+// Boot JApplicationAdministrator so the application references in the factory resolve correctly.
+JFactory::getApplication('administrator');
+
+// Set the component path (un)constants
+define('JPATH_COMPONENT', JPATH_ADMINISTRATOR . '/components/com_joomlaupdate');
+define('JPATH_COMPONENT_ADMINISTRATOR', JPATH_ADMINISTRATOR . '/components/com_joomlaupdate');
+define('JPATH_COMPONENT_SITE', JPATH_SITE . '/components/com_joomlaupdate');
+
+// Load the update component's model to run the cleanup methods
+JModelLegacy::addIncludePath(JPATH_COMPONENT_ADMINISTRATOR . '/models', 'JoomlaupdateModel');
+
+/** @var JoomlaupdateModelDefault $model */
+$model = JModelLegacy::getInstance('default', 'JoomlaupdateModel');
+
+// Make sure we got the model
+if (!($model instanceof JoomlaupdateModelDefault))
+{
+	echo 'Could not load update component model, please check the logs for additional details.' . PHP_EOL;
+
+	exit(1);
+}
+
+// Load up the logger
+JLog::addLogger(
+	array(
+		'format'    => '{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}',
+		'text_file' => 'joomla_update.php',
+	),
+	JLog::INFO,
+	array('Update', 'databasequery', 'jerror')
+);
+
+JLog::add('Starting manual update using postupdate', JLog::INFO, 'Update');
+
+// Load the Joomla library and update component language files
+JFactory::getLanguage()->load('lib_joomla');
+JFactory::getLanguage()->load('com_joomlaupdate');
+
+JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_FINALISE'), JLog::INFO, 'Update');
+
+// Finalize the update
+if ($model->finaliseUpgrade() === false)
+{
+	echo 'Failed to finalize the upgrade, please check the logs for additional details.' . PHP_EOL;
+
+	exit(1);
+}
+
+JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_CLEANUP'), JLog::INFO, 'Update');
+
+// Cleanup after the update
+$model->cleanUp();
+
+JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_COMPLETE', JVERSION), JLog::INFO, 'Update');
+JLog::add('Finished manual update using postupdate', JLog::INFO, 'Update');
+
+echo 'Update to ' . JVERSION . ' completed successfully.' . PHP_EOL;

--- a/php5.6/fpm-alpine/Dockerfile
+++ b/php5.6/fpm-alpine/Dockerfile
@@ -64,7 +64,7 @@ VOLUME /var/www/html
 ENV JOOMLA_VERSION 3.8.6
 ENV JOOMLA_SHA1 769d86c00b3add41b1fa6c85f3ec823a07df88d1
 
-# Download package and extract to web volume
+# Download package and extract to intermediate directory
 RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \
 	&& echo "$JOOMLA_SHA1 *joomla.tar.bz2" | sha1sum -c - \
 	&& mkdir /usr/src/joomla \

--- a/php5.6/fpm-alpine/Dockerfile
+++ b/php5.6/fpm-alpine/Dockerfile
@@ -75,6 +75,7 @@ RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/dow
 # Copy init scripts and custom .htaccess
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY makedb.php /makedb.php
+COPY postupdate.php /postupdate.php
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["php-fpm"]

--- a/php5.6/fpm-alpine/postupdate.php
+++ b/php5.6/fpm-alpine/postupdate.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Post-Manual Update Script
+ *
+ * from https://gist.github.com/mbabker/d7bfb4e1e2fbc6b7815a733607f89281
+ *
+ * @package    Joomla.Administrator
+ *
+ * @copyright  Copyright (C) 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+/**
+ * Define the application's minimum supported PHP version as a constant so it can be referenced within the application.
+ */
+define('JOOMLA_MINIMUM_PHP', '5.3.10');
+
+if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<'))
+{
+	die('Your host needs to use PHP ' . JOOMLA_MINIMUM_PHP . ' or higher to run this version of Joomla!');
+}
+
+/**
+ * Constant that is checked in included files to prevent direct access.
+ * define() is used in the installation folder rather than "const" to not error for PHP 5.2 and lower
+ */
+define('_JEXEC', 1);
+
+// Load the administrator application's path constants
+if (file_exists(__DIR__ . '/defines.php'))
+{
+	include_once __DIR__ . '/defines.php';
+}
+
+if (!defined('_JDEFINES'))
+{
+	define('JPATH_BASE', __DIR__);
+	require_once JPATH_BASE . '/includes/defines.php';
+}
+
+require_once JPATH_BASE . '/includes/framework.php';
+require_once JPATH_BASE . '/includes/helper.php';
+require_once JPATH_BASE . '/includes/toolbar.php';
+
+// Boot JApplicationAdministrator so the application references in the factory resolve correctly.
+JFactory::getApplication('administrator');
+
+// Set the component path (un)constants
+define('JPATH_COMPONENT', JPATH_ADMINISTRATOR . '/components/com_joomlaupdate');
+define('JPATH_COMPONENT_ADMINISTRATOR', JPATH_ADMINISTRATOR . '/components/com_joomlaupdate');
+define('JPATH_COMPONENT_SITE', JPATH_SITE . '/components/com_joomlaupdate');
+
+// Load the update component's model to run the cleanup methods
+JModelLegacy::addIncludePath(JPATH_COMPONENT_ADMINISTRATOR . '/models', 'JoomlaupdateModel');
+
+/** @var JoomlaupdateModelDefault $model */
+$model = JModelLegacy::getInstance('default', 'JoomlaupdateModel');
+
+// Make sure we got the model
+if (!($model instanceof JoomlaupdateModelDefault))
+{
+	echo 'Could not load update component model, please check the logs for additional details.' . PHP_EOL;
+
+	exit(1);
+}
+
+// Load up the logger
+JLog::addLogger(
+	array(
+		'format'    => '{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}',
+		'text_file' => 'joomla_update.php',
+	),
+	JLog::INFO,
+	array('Update', 'databasequery', 'jerror')
+);
+
+JLog::add('Starting manual update using postupdate', JLog::INFO, 'Update');
+
+// Load the Joomla library and update component language files
+JFactory::getLanguage()->load('lib_joomla');
+JFactory::getLanguage()->load('com_joomlaupdate');
+
+JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_FINALISE'), JLog::INFO, 'Update');
+
+// Finalize the update
+if ($model->finaliseUpgrade() === false)
+{
+	echo 'Failed to finalize the upgrade, please check the logs for additional details.' . PHP_EOL;
+
+	exit(1);
+}
+
+JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_CLEANUP'), JLog::INFO, 'Update');
+
+// Cleanup after the update
+$model->cleanUp();
+
+JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_COMPLETE', JVERSION), JLog::INFO, 'Update');
+JLog::add('Finished manual update using postupdate', JLog::INFO, 'Update');
+
+echo 'Update to ' . JVERSION . ' completed successfully.' . PHP_EOL;

--- a/php5.6/fpm/Dockerfile
+++ b/php5.6/fpm/Dockerfile
@@ -68,7 +68,7 @@ VOLUME /var/www/html
 ENV JOOMLA_VERSION 3.8.6
 ENV JOOMLA_SHA1 769d86c00b3add41b1fa6c85f3ec823a07df88d1
 
-# Download package and extract to web volume
+# Download package and extract to intermediate directory
 RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \
 	&& echo "$JOOMLA_SHA1 *joomla.tar.bz2" | sha1sum -c - \
 	&& mkdir /usr/src/joomla \

--- a/php5.6/fpm/Dockerfile
+++ b/php5.6/fpm/Dockerfile
@@ -79,6 +79,7 @@ RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/dow
 # Copy init scripts and custom .htaccess
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY makedb.php /makedb.php
+COPY postupdate.php /postupdate.php
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["php-fpm"]

--- a/php5.6/fpm/postupdate.php
+++ b/php5.6/fpm/postupdate.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Post-Manual Update Script
+ *
+ * from https://gist.github.com/mbabker/d7bfb4e1e2fbc6b7815a733607f89281
+ *
+ * @package    Joomla.Administrator
+ *
+ * @copyright  Copyright (C) 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+/**
+ * Define the application's minimum supported PHP version as a constant so it can be referenced within the application.
+ */
+define('JOOMLA_MINIMUM_PHP', '5.3.10');
+
+if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<'))
+{
+	die('Your host needs to use PHP ' . JOOMLA_MINIMUM_PHP . ' or higher to run this version of Joomla!');
+}
+
+/**
+ * Constant that is checked in included files to prevent direct access.
+ * define() is used in the installation folder rather than "const" to not error for PHP 5.2 and lower
+ */
+define('_JEXEC', 1);
+
+// Load the administrator application's path constants
+if (file_exists(__DIR__ . '/defines.php'))
+{
+	include_once __DIR__ . '/defines.php';
+}
+
+if (!defined('_JDEFINES'))
+{
+	define('JPATH_BASE', __DIR__);
+	require_once JPATH_BASE . '/includes/defines.php';
+}
+
+require_once JPATH_BASE . '/includes/framework.php';
+require_once JPATH_BASE . '/includes/helper.php';
+require_once JPATH_BASE . '/includes/toolbar.php';
+
+// Boot JApplicationAdministrator so the application references in the factory resolve correctly.
+JFactory::getApplication('administrator');
+
+// Set the component path (un)constants
+define('JPATH_COMPONENT', JPATH_ADMINISTRATOR . '/components/com_joomlaupdate');
+define('JPATH_COMPONENT_ADMINISTRATOR', JPATH_ADMINISTRATOR . '/components/com_joomlaupdate');
+define('JPATH_COMPONENT_SITE', JPATH_SITE . '/components/com_joomlaupdate');
+
+// Load the update component's model to run the cleanup methods
+JModelLegacy::addIncludePath(JPATH_COMPONENT_ADMINISTRATOR . '/models', 'JoomlaupdateModel');
+
+/** @var JoomlaupdateModelDefault $model */
+$model = JModelLegacy::getInstance('default', 'JoomlaupdateModel');
+
+// Make sure we got the model
+if (!($model instanceof JoomlaupdateModelDefault))
+{
+	echo 'Could not load update component model, please check the logs for additional details.' . PHP_EOL;
+
+	exit(1);
+}
+
+// Load up the logger
+JLog::addLogger(
+	array(
+		'format'    => '{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}',
+		'text_file' => 'joomla_update.php',
+	),
+	JLog::INFO,
+	array('Update', 'databasequery', 'jerror')
+);
+
+JLog::add('Starting manual update using postupdate', JLog::INFO, 'Update');
+
+// Load the Joomla library and update component language files
+JFactory::getLanguage()->load('lib_joomla');
+JFactory::getLanguage()->load('com_joomlaupdate');
+
+JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_FINALISE'), JLog::INFO, 'Update');
+
+// Finalize the update
+if ($model->finaliseUpgrade() === false)
+{
+	echo 'Failed to finalize the upgrade, please check the logs for additional details.' . PHP_EOL;
+
+	exit(1);
+}
+
+JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_CLEANUP'), JLog::INFO, 'Update');
+
+// Cleanup after the update
+$model->cleanUp();
+
+JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_COMPLETE', JVERSION), JLog::INFO, 'Update');
+JLog::add('Finished manual update using postupdate', JLog::INFO, 'Update');
+
+echo 'Update to ' . JVERSION . ' completed successfully.' . PHP_EOL;

--- a/php7.0/apache/Dockerfile
+++ b/php7.0/apache/Dockerfile
@@ -71,7 +71,7 @@ VOLUME /var/www/html
 ENV JOOMLA_VERSION 3.8.6
 ENV JOOMLA_SHA1 769d86c00b3add41b1fa6c85f3ec823a07df88d1
 
-# Download package and extract to web volume
+# Download package and extract to intermediate directory
 RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \
 	&& echo "$JOOMLA_SHA1 *joomla.tar.bz2" | sha1sum -c - \
 	&& mkdir /usr/src/joomla \

--- a/php7.0/apache/Dockerfile
+++ b/php7.0/apache/Dockerfile
@@ -82,6 +82,7 @@ RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/dow
 # Copy init scripts and custom .htaccess
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY makedb.php /makedb.php
+COPY postupdate.php /postupdate.php
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["apache2-foreground"]

--- a/php7.0/apache/postupdate.php
+++ b/php7.0/apache/postupdate.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Post-Manual Update Script
+ *
+ * from https://gist.github.com/mbabker/d7bfb4e1e2fbc6b7815a733607f89281
+ *
+ * @package    Joomla.Administrator
+ *
+ * @copyright  Copyright (C) 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+/**
+ * Define the application's minimum supported PHP version as a constant so it can be referenced within the application.
+ */
+define('JOOMLA_MINIMUM_PHP', '5.3.10');
+
+if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<'))
+{
+	die('Your host needs to use PHP ' . JOOMLA_MINIMUM_PHP . ' or higher to run this version of Joomla!');
+}
+
+/**
+ * Constant that is checked in included files to prevent direct access.
+ * define() is used in the installation folder rather than "const" to not error for PHP 5.2 and lower
+ */
+define('_JEXEC', 1);
+
+// Load the administrator application's path constants
+if (file_exists(__DIR__ . '/defines.php'))
+{
+	include_once __DIR__ . '/defines.php';
+}
+
+if (!defined('_JDEFINES'))
+{
+	define('JPATH_BASE', __DIR__);
+	require_once JPATH_BASE . '/includes/defines.php';
+}
+
+require_once JPATH_BASE . '/includes/framework.php';
+require_once JPATH_BASE . '/includes/helper.php';
+require_once JPATH_BASE . '/includes/toolbar.php';
+
+// Boot JApplicationAdministrator so the application references in the factory resolve correctly.
+JFactory::getApplication('administrator');
+
+// Set the component path (un)constants
+define('JPATH_COMPONENT', JPATH_ADMINISTRATOR . '/components/com_joomlaupdate');
+define('JPATH_COMPONENT_ADMINISTRATOR', JPATH_ADMINISTRATOR . '/components/com_joomlaupdate');
+define('JPATH_COMPONENT_SITE', JPATH_SITE . '/components/com_joomlaupdate');
+
+// Load the update component's model to run the cleanup methods
+JModelLegacy::addIncludePath(JPATH_COMPONENT_ADMINISTRATOR . '/models', 'JoomlaupdateModel');
+
+/** @var JoomlaupdateModelDefault $model */
+$model = JModelLegacy::getInstance('default', 'JoomlaupdateModel');
+
+// Make sure we got the model
+if (!($model instanceof JoomlaupdateModelDefault))
+{
+	echo 'Could not load update component model, please check the logs for additional details.' . PHP_EOL;
+
+	exit(1);
+}
+
+// Load up the logger
+JLog::addLogger(
+	array(
+		'format'    => '{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}',
+		'text_file' => 'joomla_update.php',
+	),
+	JLog::INFO,
+	array('Update', 'databasequery', 'jerror')
+);
+
+JLog::add('Starting manual update using postupdate', JLog::INFO, 'Update');
+
+// Load the Joomla library and update component language files
+JFactory::getLanguage()->load('lib_joomla');
+JFactory::getLanguage()->load('com_joomlaupdate');
+
+JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_FINALISE'), JLog::INFO, 'Update');
+
+// Finalize the update
+if ($model->finaliseUpgrade() === false)
+{
+	echo 'Failed to finalize the upgrade, please check the logs for additional details.' . PHP_EOL;
+
+	exit(1);
+}
+
+JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_CLEANUP'), JLog::INFO, 'Update');
+
+// Cleanup after the update
+$model->cleanUp();
+
+JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_COMPLETE', JVERSION), JLog::INFO, 'Update');
+JLog::add('Finished manual update using postupdate', JLog::INFO, 'Update');
+
+echo 'Update to ' . JVERSION . ' completed successfully.' . PHP_EOL;

--- a/php7.0/fpm-alpine/Dockerfile
+++ b/php7.0/fpm-alpine/Dockerfile
@@ -64,7 +64,7 @@ VOLUME /var/www/html
 ENV JOOMLA_VERSION 3.8.6
 ENV JOOMLA_SHA1 769d86c00b3add41b1fa6c85f3ec823a07df88d1
 
-# Download package and extract to web volume
+# Download package and extract to intermediate directory
 RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \
 	&& echo "$JOOMLA_SHA1 *joomla.tar.bz2" | sha1sum -c - \
 	&& mkdir /usr/src/joomla \

--- a/php7.0/fpm-alpine/Dockerfile
+++ b/php7.0/fpm-alpine/Dockerfile
@@ -75,6 +75,7 @@ RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/dow
 # Copy init scripts and custom .htaccess
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY makedb.php /makedb.php
+COPY postupdate.php /postupdate.php
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["php-fpm"]

--- a/php7.0/fpm-alpine/postupdate.php
+++ b/php7.0/fpm-alpine/postupdate.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Post-Manual Update Script
+ *
+ * from https://gist.github.com/mbabker/d7bfb4e1e2fbc6b7815a733607f89281
+ *
+ * @package    Joomla.Administrator
+ *
+ * @copyright  Copyright (C) 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+/**
+ * Define the application's minimum supported PHP version as a constant so it can be referenced within the application.
+ */
+define('JOOMLA_MINIMUM_PHP', '5.3.10');
+
+if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<'))
+{
+	die('Your host needs to use PHP ' . JOOMLA_MINIMUM_PHP . ' or higher to run this version of Joomla!');
+}
+
+/**
+ * Constant that is checked in included files to prevent direct access.
+ * define() is used in the installation folder rather than "const" to not error for PHP 5.2 and lower
+ */
+define('_JEXEC', 1);
+
+// Load the administrator application's path constants
+if (file_exists(__DIR__ . '/defines.php'))
+{
+	include_once __DIR__ . '/defines.php';
+}
+
+if (!defined('_JDEFINES'))
+{
+	define('JPATH_BASE', __DIR__);
+	require_once JPATH_BASE . '/includes/defines.php';
+}
+
+require_once JPATH_BASE . '/includes/framework.php';
+require_once JPATH_BASE . '/includes/helper.php';
+require_once JPATH_BASE . '/includes/toolbar.php';
+
+// Boot JApplicationAdministrator so the application references in the factory resolve correctly.
+JFactory::getApplication('administrator');
+
+// Set the component path (un)constants
+define('JPATH_COMPONENT', JPATH_ADMINISTRATOR . '/components/com_joomlaupdate');
+define('JPATH_COMPONENT_ADMINISTRATOR', JPATH_ADMINISTRATOR . '/components/com_joomlaupdate');
+define('JPATH_COMPONENT_SITE', JPATH_SITE . '/components/com_joomlaupdate');
+
+// Load the update component's model to run the cleanup methods
+JModelLegacy::addIncludePath(JPATH_COMPONENT_ADMINISTRATOR . '/models', 'JoomlaupdateModel');
+
+/** @var JoomlaupdateModelDefault $model */
+$model = JModelLegacy::getInstance('default', 'JoomlaupdateModel');
+
+// Make sure we got the model
+if (!($model instanceof JoomlaupdateModelDefault))
+{
+	echo 'Could not load update component model, please check the logs for additional details.' . PHP_EOL;
+
+	exit(1);
+}
+
+// Load up the logger
+JLog::addLogger(
+	array(
+		'format'    => '{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}',
+		'text_file' => 'joomla_update.php',
+	),
+	JLog::INFO,
+	array('Update', 'databasequery', 'jerror')
+);
+
+JLog::add('Starting manual update using postupdate', JLog::INFO, 'Update');
+
+// Load the Joomla library and update component language files
+JFactory::getLanguage()->load('lib_joomla');
+JFactory::getLanguage()->load('com_joomlaupdate');
+
+JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_FINALISE'), JLog::INFO, 'Update');
+
+// Finalize the update
+if ($model->finaliseUpgrade() === false)
+{
+	echo 'Failed to finalize the upgrade, please check the logs for additional details.' . PHP_EOL;
+
+	exit(1);
+}
+
+JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_CLEANUP'), JLog::INFO, 'Update');
+
+// Cleanup after the update
+$model->cleanUp();
+
+JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_COMPLETE', JVERSION), JLog::INFO, 'Update');
+JLog::add('Finished manual update using postupdate', JLog::INFO, 'Update');
+
+echo 'Update to ' . JVERSION . ' completed successfully.' . PHP_EOL;

--- a/php7.0/fpm/Dockerfile
+++ b/php7.0/fpm/Dockerfile
@@ -68,7 +68,7 @@ VOLUME /var/www/html
 ENV JOOMLA_VERSION 3.8.6
 ENV JOOMLA_SHA1 769d86c00b3add41b1fa6c85f3ec823a07df88d1
 
-# Download package and extract to web volume
+# Download package and extract to intermediate directory
 RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \
 	&& echo "$JOOMLA_SHA1 *joomla.tar.bz2" | sha1sum -c - \
 	&& mkdir /usr/src/joomla \

--- a/php7.0/fpm/Dockerfile
+++ b/php7.0/fpm/Dockerfile
@@ -79,6 +79,7 @@ RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/dow
 # Copy init scripts and custom .htaccess
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY makedb.php /makedb.php
+COPY postupdate.php /postupdate.php
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["php-fpm"]

--- a/php7.0/fpm/postupdate.php
+++ b/php7.0/fpm/postupdate.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Post-Manual Update Script
+ *
+ * from https://gist.github.com/mbabker/d7bfb4e1e2fbc6b7815a733607f89281
+ *
+ * @package    Joomla.Administrator
+ *
+ * @copyright  Copyright (C) 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+/**
+ * Define the application's minimum supported PHP version as a constant so it can be referenced within the application.
+ */
+define('JOOMLA_MINIMUM_PHP', '5.3.10');
+
+if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<'))
+{
+	die('Your host needs to use PHP ' . JOOMLA_MINIMUM_PHP . ' or higher to run this version of Joomla!');
+}
+
+/**
+ * Constant that is checked in included files to prevent direct access.
+ * define() is used in the installation folder rather than "const" to not error for PHP 5.2 and lower
+ */
+define('_JEXEC', 1);
+
+// Load the administrator application's path constants
+if (file_exists(__DIR__ . '/defines.php'))
+{
+	include_once __DIR__ . '/defines.php';
+}
+
+if (!defined('_JDEFINES'))
+{
+	define('JPATH_BASE', __DIR__);
+	require_once JPATH_BASE . '/includes/defines.php';
+}
+
+require_once JPATH_BASE . '/includes/framework.php';
+require_once JPATH_BASE . '/includes/helper.php';
+require_once JPATH_BASE . '/includes/toolbar.php';
+
+// Boot JApplicationAdministrator so the application references in the factory resolve correctly.
+JFactory::getApplication('administrator');
+
+// Set the component path (un)constants
+define('JPATH_COMPONENT', JPATH_ADMINISTRATOR . '/components/com_joomlaupdate');
+define('JPATH_COMPONENT_ADMINISTRATOR', JPATH_ADMINISTRATOR . '/components/com_joomlaupdate');
+define('JPATH_COMPONENT_SITE', JPATH_SITE . '/components/com_joomlaupdate');
+
+// Load the update component's model to run the cleanup methods
+JModelLegacy::addIncludePath(JPATH_COMPONENT_ADMINISTRATOR . '/models', 'JoomlaupdateModel');
+
+/** @var JoomlaupdateModelDefault $model */
+$model = JModelLegacy::getInstance('default', 'JoomlaupdateModel');
+
+// Make sure we got the model
+if (!($model instanceof JoomlaupdateModelDefault))
+{
+	echo 'Could not load update component model, please check the logs for additional details.' . PHP_EOL;
+
+	exit(1);
+}
+
+// Load up the logger
+JLog::addLogger(
+	array(
+		'format'    => '{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}',
+		'text_file' => 'joomla_update.php',
+	),
+	JLog::INFO,
+	array('Update', 'databasequery', 'jerror')
+);
+
+JLog::add('Starting manual update using postupdate', JLog::INFO, 'Update');
+
+// Load the Joomla library and update component language files
+JFactory::getLanguage()->load('lib_joomla');
+JFactory::getLanguage()->load('com_joomlaupdate');
+
+JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_FINALISE'), JLog::INFO, 'Update');
+
+// Finalize the update
+if ($model->finaliseUpgrade() === false)
+{
+	echo 'Failed to finalize the upgrade, please check the logs for additional details.' . PHP_EOL;
+
+	exit(1);
+}
+
+JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_CLEANUP'), JLog::INFO, 'Update');
+
+// Cleanup after the update
+$model->cleanUp();
+
+JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_COMPLETE', JVERSION), JLog::INFO, 'Update');
+JLog::add('Finished manual update using postupdate', JLog::INFO, 'Update');
+
+echo 'Update to ' . JVERSION . ' completed successfully.' . PHP_EOL;

--- a/php7.1/apache/Dockerfile
+++ b/php7.1/apache/Dockerfile
@@ -71,7 +71,7 @@ VOLUME /var/www/html
 ENV JOOMLA_VERSION 3.8.6
 ENV JOOMLA_SHA1 769d86c00b3add41b1fa6c85f3ec823a07df88d1
 
-# Download package and extract to web volume
+# Download package and extract to intermediate directory
 RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \
 	&& echo "$JOOMLA_SHA1 *joomla.tar.bz2" | sha1sum -c - \
 	&& mkdir /usr/src/joomla \

--- a/php7.1/apache/Dockerfile
+++ b/php7.1/apache/Dockerfile
@@ -82,6 +82,7 @@ RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/dow
 # Copy init scripts and custom .htaccess
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY makedb.php /makedb.php
+COPY postupdate.php /postupdate.php
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["apache2-foreground"]

--- a/php7.1/apache/postupdate.php
+++ b/php7.1/apache/postupdate.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Post-Manual Update Script
+ *
+ * from https://gist.github.com/mbabker/d7bfb4e1e2fbc6b7815a733607f89281
+ *
+ * @package    Joomla.Administrator
+ *
+ * @copyright  Copyright (C) 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+/**
+ * Define the application's minimum supported PHP version as a constant so it can be referenced within the application.
+ */
+define('JOOMLA_MINIMUM_PHP', '5.3.10');
+
+if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<'))
+{
+	die('Your host needs to use PHP ' . JOOMLA_MINIMUM_PHP . ' or higher to run this version of Joomla!');
+}
+
+/**
+ * Constant that is checked in included files to prevent direct access.
+ * define() is used in the installation folder rather than "const" to not error for PHP 5.2 and lower
+ */
+define('_JEXEC', 1);
+
+// Load the administrator application's path constants
+if (file_exists(__DIR__ . '/defines.php'))
+{
+	include_once __DIR__ . '/defines.php';
+}
+
+if (!defined('_JDEFINES'))
+{
+	define('JPATH_BASE', __DIR__);
+	require_once JPATH_BASE . '/includes/defines.php';
+}
+
+require_once JPATH_BASE . '/includes/framework.php';
+require_once JPATH_BASE . '/includes/helper.php';
+require_once JPATH_BASE . '/includes/toolbar.php';
+
+// Boot JApplicationAdministrator so the application references in the factory resolve correctly.
+JFactory::getApplication('administrator');
+
+// Set the component path (un)constants
+define('JPATH_COMPONENT', JPATH_ADMINISTRATOR . '/components/com_joomlaupdate');
+define('JPATH_COMPONENT_ADMINISTRATOR', JPATH_ADMINISTRATOR . '/components/com_joomlaupdate');
+define('JPATH_COMPONENT_SITE', JPATH_SITE . '/components/com_joomlaupdate');
+
+// Load the update component's model to run the cleanup methods
+JModelLegacy::addIncludePath(JPATH_COMPONENT_ADMINISTRATOR . '/models', 'JoomlaupdateModel');
+
+/** @var JoomlaupdateModelDefault $model */
+$model = JModelLegacy::getInstance('default', 'JoomlaupdateModel');
+
+// Make sure we got the model
+if (!($model instanceof JoomlaupdateModelDefault))
+{
+	echo 'Could not load update component model, please check the logs for additional details.' . PHP_EOL;
+
+	exit(1);
+}
+
+// Load up the logger
+JLog::addLogger(
+	array(
+		'format'    => '{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}',
+		'text_file' => 'joomla_update.php',
+	),
+	JLog::INFO,
+	array('Update', 'databasequery', 'jerror')
+);
+
+JLog::add('Starting manual update using postupdate', JLog::INFO, 'Update');
+
+// Load the Joomla library and update component language files
+JFactory::getLanguage()->load('lib_joomla');
+JFactory::getLanguage()->load('com_joomlaupdate');
+
+JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_FINALISE'), JLog::INFO, 'Update');
+
+// Finalize the update
+if ($model->finaliseUpgrade() === false)
+{
+	echo 'Failed to finalize the upgrade, please check the logs for additional details.' . PHP_EOL;
+
+	exit(1);
+}
+
+JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_CLEANUP'), JLog::INFO, 'Update');
+
+// Cleanup after the update
+$model->cleanUp();
+
+JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_COMPLETE', JVERSION), JLog::INFO, 'Update');
+JLog::add('Finished manual update using postupdate', JLog::INFO, 'Update');
+
+echo 'Update to ' . JVERSION . ' completed successfully.' . PHP_EOL;

--- a/php7.1/fpm-alpine/Dockerfile
+++ b/php7.1/fpm-alpine/Dockerfile
@@ -64,7 +64,7 @@ VOLUME /var/www/html
 ENV JOOMLA_VERSION 3.8.6
 ENV JOOMLA_SHA1 769d86c00b3add41b1fa6c85f3ec823a07df88d1
 
-# Download package and extract to web volume
+# Download package and extract to intermediate directory
 RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \
 	&& echo "$JOOMLA_SHA1 *joomla.tar.bz2" | sha1sum -c - \
 	&& mkdir /usr/src/joomla \

--- a/php7.1/fpm-alpine/Dockerfile
+++ b/php7.1/fpm-alpine/Dockerfile
@@ -75,6 +75,7 @@ RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/dow
 # Copy init scripts and custom .htaccess
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY makedb.php /makedb.php
+COPY postupdate.php /postupdate.php
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["php-fpm"]

--- a/php7.1/fpm-alpine/postupdate.php
+++ b/php7.1/fpm-alpine/postupdate.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Post-Manual Update Script
+ *
+ * from https://gist.github.com/mbabker/d7bfb4e1e2fbc6b7815a733607f89281
+ *
+ * @package    Joomla.Administrator
+ *
+ * @copyright  Copyright (C) 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+/**
+ * Define the application's minimum supported PHP version as a constant so it can be referenced within the application.
+ */
+define('JOOMLA_MINIMUM_PHP', '5.3.10');
+
+if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<'))
+{
+	die('Your host needs to use PHP ' . JOOMLA_MINIMUM_PHP . ' or higher to run this version of Joomla!');
+}
+
+/**
+ * Constant that is checked in included files to prevent direct access.
+ * define() is used in the installation folder rather than "const" to not error for PHP 5.2 and lower
+ */
+define('_JEXEC', 1);
+
+// Load the administrator application's path constants
+if (file_exists(__DIR__ . '/defines.php'))
+{
+	include_once __DIR__ . '/defines.php';
+}
+
+if (!defined('_JDEFINES'))
+{
+	define('JPATH_BASE', __DIR__);
+	require_once JPATH_BASE . '/includes/defines.php';
+}
+
+require_once JPATH_BASE . '/includes/framework.php';
+require_once JPATH_BASE . '/includes/helper.php';
+require_once JPATH_BASE . '/includes/toolbar.php';
+
+// Boot JApplicationAdministrator so the application references in the factory resolve correctly.
+JFactory::getApplication('administrator');
+
+// Set the component path (un)constants
+define('JPATH_COMPONENT', JPATH_ADMINISTRATOR . '/components/com_joomlaupdate');
+define('JPATH_COMPONENT_ADMINISTRATOR', JPATH_ADMINISTRATOR . '/components/com_joomlaupdate');
+define('JPATH_COMPONENT_SITE', JPATH_SITE . '/components/com_joomlaupdate');
+
+// Load the update component's model to run the cleanup methods
+JModelLegacy::addIncludePath(JPATH_COMPONENT_ADMINISTRATOR . '/models', 'JoomlaupdateModel');
+
+/** @var JoomlaupdateModelDefault $model */
+$model = JModelLegacy::getInstance('default', 'JoomlaupdateModel');
+
+// Make sure we got the model
+if (!($model instanceof JoomlaupdateModelDefault))
+{
+	echo 'Could not load update component model, please check the logs for additional details.' . PHP_EOL;
+
+	exit(1);
+}
+
+// Load up the logger
+JLog::addLogger(
+	array(
+		'format'    => '{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}',
+		'text_file' => 'joomla_update.php',
+	),
+	JLog::INFO,
+	array('Update', 'databasequery', 'jerror')
+);
+
+JLog::add('Starting manual update using postupdate', JLog::INFO, 'Update');
+
+// Load the Joomla library and update component language files
+JFactory::getLanguage()->load('lib_joomla');
+JFactory::getLanguage()->load('com_joomlaupdate');
+
+JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_FINALISE'), JLog::INFO, 'Update');
+
+// Finalize the update
+if ($model->finaliseUpgrade() === false)
+{
+	echo 'Failed to finalize the upgrade, please check the logs for additional details.' . PHP_EOL;
+
+	exit(1);
+}
+
+JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_CLEANUP'), JLog::INFO, 'Update');
+
+// Cleanup after the update
+$model->cleanUp();
+
+JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_COMPLETE', JVERSION), JLog::INFO, 'Update');
+JLog::add('Finished manual update using postupdate', JLog::INFO, 'Update');
+
+echo 'Update to ' . JVERSION . ' completed successfully.' . PHP_EOL;

--- a/php7.1/fpm/Dockerfile
+++ b/php7.1/fpm/Dockerfile
@@ -68,7 +68,7 @@ VOLUME /var/www/html
 ENV JOOMLA_VERSION 3.8.6
 ENV JOOMLA_SHA1 769d86c00b3add41b1fa6c85f3ec823a07df88d1
 
-# Download package and extract to web volume
+# Download package and extract to intermediate directory
 RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \
 	&& echo "$JOOMLA_SHA1 *joomla.tar.bz2" | sha1sum -c - \
 	&& mkdir /usr/src/joomla \

--- a/php7.1/fpm/Dockerfile
+++ b/php7.1/fpm/Dockerfile
@@ -79,6 +79,7 @@ RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/dow
 # Copy init scripts and custom .htaccess
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY makedb.php /makedb.php
+COPY postupdate.php /postupdate.php
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["php-fpm"]

--- a/php7.1/fpm/postupdate.php
+++ b/php7.1/fpm/postupdate.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Post-Manual Update Script
+ *
+ * from https://gist.github.com/mbabker/d7bfb4e1e2fbc6b7815a733607f89281
+ *
+ * @package    Joomla.Administrator
+ *
+ * @copyright  Copyright (C) 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+/**
+ * Define the application's minimum supported PHP version as a constant so it can be referenced within the application.
+ */
+define('JOOMLA_MINIMUM_PHP', '5.3.10');
+
+if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<'))
+{
+	die('Your host needs to use PHP ' . JOOMLA_MINIMUM_PHP . ' or higher to run this version of Joomla!');
+}
+
+/**
+ * Constant that is checked in included files to prevent direct access.
+ * define() is used in the installation folder rather than "const" to not error for PHP 5.2 and lower
+ */
+define('_JEXEC', 1);
+
+// Load the administrator application's path constants
+if (file_exists(__DIR__ . '/defines.php'))
+{
+	include_once __DIR__ . '/defines.php';
+}
+
+if (!defined('_JDEFINES'))
+{
+	define('JPATH_BASE', __DIR__);
+	require_once JPATH_BASE . '/includes/defines.php';
+}
+
+require_once JPATH_BASE . '/includes/framework.php';
+require_once JPATH_BASE . '/includes/helper.php';
+require_once JPATH_BASE . '/includes/toolbar.php';
+
+// Boot JApplicationAdministrator so the application references in the factory resolve correctly.
+JFactory::getApplication('administrator');
+
+// Set the component path (un)constants
+define('JPATH_COMPONENT', JPATH_ADMINISTRATOR . '/components/com_joomlaupdate');
+define('JPATH_COMPONENT_ADMINISTRATOR', JPATH_ADMINISTRATOR . '/components/com_joomlaupdate');
+define('JPATH_COMPONENT_SITE', JPATH_SITE . '/components/com_joomlaupdate');
+
+// Load the update component's model to run the cleanup methods
+JModelLegacy::addIncludePath(JPATH_COMPONENT_ADMINISTRATOR . '/models', 'JoomlaupdateModel');
+
+/** @var JoomlaupdateModelDefault $model */
+$model = JModelLegacy::getInstance('default', 'JoomlaupdateModel');
+
+// Make sure we got the model
+if (!($model instanceof JoomlaupdateModelDefault))
+{
+	echo 'Could not load update component model, please check the logs for additional details.' . PHP_EOL;
+
+	exit(1);
+}
+
+// Load up the logger
+JLog::addLogger(
+	array(
+		'format'    => '{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}',
+		'text_file' => 'joomla_update.php',
+	),
+	JLog::INFO,
+	array('Update', 'databasequery', 'jerror')
+);
+
+JLog::add('Starting manual update using postupdate', JLog::INFO, 'Update');
+
+// Load the Joomla library and update component language files
+JFactory::getLanguage()->load('lib_joomla');
+JFactory::getLanguage()->load('com_joomlaupdate');
+
+JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_FINALISE'), JLog::INFO, 'Update');
+
+// Finalize the update
+if ($model->finaliseUpgrade() === false)
+{
+	echo 'Failed to finalize the upgrade, please check the logs for additional details.' . PHP_EOL;
+
+	exit(1);
+}
+
+JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_CLEANUP'), JLog::INFO, 'Update');
+
+// Cleanup after the update
+$model->cleanUp();
+
+JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_COMPLETE', JVERSION), JLog::INFO, 'Update');
+JLog::add('Finished manual update using postupdate', JLog::INFO, 'Update');
+
+echo 'Update to ' . JVERSION . ' completed successfully.' . PHP_EOL;

--- a/php7.2/apache/Dockerfile
+++ b/php7.2/apache/Dockerfile
@@ -69,7 +69,7 @@ VOLUME /var/www/html
 ENV JOOMLA_VERSION 3.8.6
 ENV JOOMLA_SHA1 769d86c00b3add41b1fa6c85f3ec823a07df88d1
 
-# Download package and extract to web volume
+# Download package and extract to intermediate directory
 RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \
 	&& echo "$JOOMLA_SHA1 *joomla.tar.bz2" | sha1sum -c - \
 	&& mkdir /usr/src/joomla \

--- a/php7.2/apache/Dockerfile
+++ b/php7.2/apache/Dockerfile
@@ -80,6 +80,7 @@ RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/dow
 # Copy init scripts and custom .htaccess
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY makedb.php /makedb.php
+COPY postupdate.php /postupdate.php
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["apache2-foreground"]

--- a/php7.2/apache/postupdate.php
+++ b/php7.2/apache/postupdate.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Post-Manual Update Script
+ *
+ * from https://gist.github.com/mbabker/d7bfb4e1e2fbc6b7815a733607f89281
+ *
+ * @package    Joomla.Administrator
+ *
+ * @copyright  Copyright (C) 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+/**
+ * Define the application's minimum supported PHP version as a constant so it can be referenced within the application.
+ */
+define('JOOMLA_MINIMUM_PHP', '5.3.10');
+
+if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<'))
+{
+	die('Your host needs to use PHP ' . JOOMLA_MINIMUM_PHP . ' or higher to run this version of Joomla!');
+}
+
+/**
+ * Constant that is checked in included files to prevent direct access.
+ * define() is used in the installation folder rather than "const" to not error for PHP 5.2 and lower
+ */
+define('_JEXEC', 1);
+
+// Load the administrator application's path constants
+if (file_exists(__DIR__ . '/defines.php'))
+{
+	include_once __DIR__ . '/defines.php';
+}
+
+if (!defined('_JDEFINES'))
+{
+	define('JPATH_BASE', __DIR__);
+	require_once JPATH_BASE . '/includes/defines.php';
+}
+
+require_once JPATH_BASE . '/includes/framework.php';
+require_once JPATH_BASE . '/includes/helper.php';
+require_once JPATH_BASE . '/includes/toolbar.php';
+
+// Boot JApplicationAdministrator so the application references in the factory resolve correctly.
+JFactory::getApplication('administrator');
+
+// Set the component path (un)constants
+define('JPATH_COMPONENT', JPATH_ADMINISTRATOR . '/components/com_joomlaupdate');
+define('JPATH_COMPONENT_ADMINISTRATOR', JPATH_ADMINISTRATOR . '/components/com_joomlaupdate');
+define('JPATH_COMPONENT_SITE', JPATH_SITE . '/components/com_joomlaupdate');
+
+// Load the update component's model to run the cleanup methods
+JModelLegacy::addIncludePath(JPATH_COMPONENT_ADMINISTRATOR . '/models', 'JoomlaupdateModel');
+
+/** @var JoomlaupdateModelDefault $model */
+$model = JModelLegacy::getInstance('default', 'JoomlaupdateModel');
+
+// Make sure we got the model
+if (!($model instanceof JoomlaupdateModelDefault))
+{
+	echo 'Could not load update component model, please check the logs for additional details.' . PHP_EOL;
+
+	exit(1);
+}
+
+// Load up the logger
+JLog::addLogger(
+	array(
+		'format'    => '{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}',
+		'text_file' => 'joomla_update.php',
+	),
+	JLog::INFO,
+	array('Update', 'databasequery', 'jerror')
+);
+
+JLog::add('Starting manual update using postupdate', JLog::INFO, 'Update');
+
+// Load the Joomla library and update component language files
+JFactory::getLanguage()->load('lib_joomla');
+JFactory::getLanguage()->load('com_joomlaupdate');
+
+JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_FINALISE'), JLog::INFO, 'Update');
+
+// Finalize the update
+if ($model->finaliseUpgrade() === false)
+{
+	echo 'Failed to finalize the upgrade, please check the logs for additional details.' . PHP_EOL;
+
+	exit(1);
+}
+
+JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_CLEANUP'), JLog::INFO, 'Update');
+
+// Cleanup after the update
+$model->cleanUp();
+
+JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_COMPLETE', JVERSION), JLog::INFO, 'Update');
+JLog::add('Finished manual update using postupdate', JLog::INFO, 'Update');
+
+echo 'Update to ' . JVERSION . ' completed successfully.' . PHP_EOL;

--- a/php7.2/fpm-alpine/Dockerfile
+++ b/php7.2/fpm-alpine/Dockerfile
@@ -73,6 +73,7 @@ RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/dow
 # Copy init scripts and custom .htaccess
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY makedb.php /makedb.php
+COPY postupdate.php /postupdate.php
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["php-fpm"]

--- a/php7.2/fpm-alpine/Dockerfile
+++ b/php7.2/fpm-alpine/Dockerfile
@@ -62,7 +62,7 @@ VOLUME /var/www/html
 ENV JOOMLA_VERSION 3.8.6
 ENV JOOMLA_SHA1 769d86c00b3add41b1fa6c85f3ec823a07df88d1
 
-# Download package and extract to web volume
+# Download package and extract to intermediate directory
 RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \
 	&& echo "$JOOMLA_SHA1 *joomla.tar.bz2" | sha1sum -c - \
 	&& mkdir /usr/src/joomla \

--- a/php7.2/fpm-alpine/postupdate.php
+++ b/php7.2/fpm-alpine/postupdate.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Post-Manual Update Script
+ *
+ * from https://gist.github.com/mbabker/d7bfb4e1e2fbc6b7815a733607f89281
+ *
+ * @package    Joomla.Administrator
+ *
+ * @copyright  Copyright (C) 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+/**
+ * Define the application's minimum supported PHP version as a constant so it can be referenced within the application.
+ */
+define('JOOMLA_MINIMUM_PHP', '5.3.10');
+
+if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<'))
+{
+	die('Your host needs to use PHP ' . JOOMLA_MINIMUM_PHP . ' or higher to run this version of Joomla!');
+}
+
+/**
+ * Constant that is checked in included files to prevent direct access.
+ * define() is used in the installation folder rather than "const" to not error for PHP 5.2 and lower
+ */
+define('_JEXEC', 1);
+
+// Load the administrator application's path constants
+if (file_exists(__DIR__ . '/defines.php'))
+{
+	include_once __DIR__ . '/defines.php';
+}
+
+if (!defined('_JDEFINES'))
+{
+	define('JPATH_BASE', __DIR__);
+	require_once JPATH_BASE . '/includes/defines.php';
+}
+
+require_once JPATH_BASE . '/includes/framework.php';
+require_once JPATH_BASE . '/includes/helper.php';
+require_once JPATH_BASE . '/includes/toolbar.php';
+
+// Boot JApplicationAdministrator so the application references in the factory resolve correctly.
+JFactory::getApplication('administrator');
+
+// Set the component path (un)constants
+define('JPATH_COMPONENT', JPATH_ADMINISTRATOR . '/components/com_joomlaupdate');
+define('JPATH_COMPONENT_ADMINISTRATOR', JPATH_ADMINISTRATOR . '/components/com_joomlaupdate');
+define('JPATH_COMPONENT_SITE', JPATH_SITE . '/components/com_joomlaupdate');
+
+// Load the update component's model to run the cleanup methods
+JModelLegacy::addIncludePath(JPATH_COMPONENT_ADMINISTRATOR . '/models', 'JoomlaupdateModel');
+
+/** @var JoomlaupdateModelDefault $model */
+$model = JModelLegacy::getInstance('default', 'JoomlaupdateModel');
+
+// Make sure we got the model
+if (!($model instanceof JoomlaupdateModelDefault))
+{
+	echo 'Could not load update component model, please check the logs for additional details.' . PHP_EOL;
+
+	exit(1);
+}
+
+// Load up the logger
+JLog::addLogger(
+	array(
+		'format'    => '{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}',
+		'text_file' => 'joomla_update.php',
+	),
+	JLog::INFO,
+	array('Update', 'databasequery', 'jerror')
+);
+
+JLog::add('Starting manual update using postupdate', JLog::INFO, 'Update');
+
+// Load the Joomla library and update component language files
+JFactory::getLanguage()->load('lib_joomla');
+JFactory::getLanguage()->load('com_joomlaupdate');
+
+JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_FINALISE'), JLog::INFO, 'Update');
+
+// Finalize the update
+if ($model->finaliseUpgrade() === false)
+{
+	echo 'Failed to finalize the upgrade, please check the logs for additional details.' . PHP_EOL;
+
+	exit(1);
+}
+
+JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_CLEANUP'), JLog::INFO, 'Update');
+
+// Cleanup after the update
+$model->cleanUp();
+
+JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_COMPLETE', JVERSION), JLog::INFO, 'Update');
+JLog::add('Finished manual update using postupdate', JLog::INFO, 'Update');
+
+echo 'Update to ' . JVERSION . ' completed successfully.' . PHP_EOL;

--- a/php7.2/fpm/Dockerfile
+++ b/php7.2/fpm/Dockerfile
@@ -66,7 +66,7 @@ VOLUME /var/www/html
 ENV JOOMLA_VERSION 3.8.6
 ENV JOOMLA_SHA1 769d86c00b3add41b1fa6c85f3ec823a07df88d1
 
-# Download package and extract to web volume
+# Download package and extract to intermediate directory
 RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/download/${JOOMLA_VERSION}/Joomla_${JOOMLA_VERSION}-Stable-Full_Package.tar.bz2 \
 	&& echo "$JOOMLA_SHA1 *joomla.tar.bz2" | sha1sum -c - \
 	&& mkdir /usr/src/joomla \

--- a/php7.2/fpm/Dockerfile
+++ b/php7.2/fpm/Dockerfile
@@ -77,6 +77,7 @@ RUN curl -o joomla.tar.bz2 -SL https://github.com/joomla/joomla-cms/releases/dow
 # Copy init scripts and custom .htaccess
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY makedb.php /makedb.php
+COPY postupdate.php /postupdate.php
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["php-fpm"]

--- a/php7.2/fpm/postupdate.php
+++ b/php7.2/fpm/postupdate.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Post-Manual Update Script
+ *
+ * from https://gist.github.com/mbabker/d7bfb4e1e2fbc6b7815a733607f89281
+ *
+ * @package    Joomla.Administrator
+ *
+ * @copyright  Copyright (C) 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+/**
+ * Define the application's minimum supported PHP version as a constant so it can be referenced within the application.
+ */
+define('JOOMLA_MINIMUM_PHP', '5.3.10');
+
+if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<'))
+{
+	die('Your host needs to use PHP ' . JOOMLA_MINIMUM_PHP . ' or higher to run this version of Joomla!');
+}
+
+/**
+ * Constant that is checked in included files to prevent direct access.
+ * define() is used in the installation folder rather than "const" to not error for PHP 5.2 and lower
+ */
+define('_JEXEC', 1);
+
+// Load the administrator application's path constants
+if (file_exists(__DIR__ . '/defines.php'))
+{
+	include_once __DIR__ . '/defines.php';
+}
+
+if (!defined('_JDEFINES'))
+{
+	define('JPATH_BASE', __DIR__);
+	require_once JPATH_BASE . '/includes/defines.php';
+}
+
+require_once JPATH_BASE . '/includes/framework.php';
+require_once JPATH_BASE . '/includes/helper.php';
+require_once JPATH_BASE . '/includes/toolbar.php';
+
+// Boot JApplicationAdministrator so the application references in the factory resolve correctly.
+JFactory::getApplication('administrator');
+
+// Set the component path (un)constants
+define('JPATH_COMPONENT', JPATH_ADMINISTRATOR . '/components/com_joomlaupdate');
+define('JPATH_COMPONENT_ADMINISTRATOR', JPATH_ADMINISTRATOR . '/components/com_joomlaupdate');
+define('JPATH_COMPONENT_SITE', JPATH_SITE . '/components/com_joomlaupdate');
+
+// Load the update component's model to run the cleanup methods
+JModelLegacy::addIncludePath(JPATH_COMPONENT_ADMINISTRATOR . '/models', 'JoomlaupdateModel');
+
+/** @var JoomlaupdateModelDefault $model */
+$model = JModelLegacy::getInstance('default', 'JoomlaupdateModel');
+
+// Make sure we got the model
+if (!($model instanceof JoomlaupdateModelDefault))
+{
+	echo 'Could not load update component model, please check the logs for additional details.' . PHP_EOL;
+
+	exit(1);
+}
+
+// Load up the logger
+JLog::addLogger(
+	array(
+		'format'    => '{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}',
+		'text_file' => 'joomla_update.php',
+	),
+	JLog::INFO,
+	array('Update', 'databasequery', 'jerror')
+);
+
+JLog::add('Starting manual update using postupdate', JLog::INFO, 'Update');
+
+// Load the Joomla library and update component language files
+JFactory::getLanguage()->load('lib_joomla');
+JFactory::getLanguage()->load('com_joomlaupdate');
+
+JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_FINALISE'), JLog::INFO, 'Update');
+
+// Finalize the update
+if ($model->finaliseUpgrade() === false)
+{
+	echo 'Failed to finalize the upgrade, please check the logs for additional details.' . PHP_EOL;
+
+	exit(1);
+}
+
+JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_CLEANUP'), JLog::INFO, 'Update');
+
+// Cleanup after the update
+$model->cleanUp();
+
+JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_COMPLETE', JVERSION), JLog::INFO, 'Update');
+JLog::add('Finished manual update using postupdate', JLog::INFO, 'Update');
+
+echo 'Update to ' . JVERSION . ' completed successfully.' . PHP_EOL;

--- a/postupdate.php
+++ b/postupdate.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Post-Manual Update Script
+ *
+ * from https://gist.github.com/mbabker/d7bfb4e1e2fbc6b7815a733607f89281
+ *
+ * @package    Joomla.Administrator
+ *
+ * @copyright  Copyright (C) 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+/**
+ * Define the application's minimum supported PHP version as a constant so it can be referenced within the application.
+ */
+define('JOOMLA_MINIMUM_PHP', '5.3.10');
+
+if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<'))
+{
+	die('Your host needs to use PHP ' . JOOMLA_MINIMUM_PHP . ' or higher to run this version of Joomla!');
+}
+
+/**
+ * Constant that is checked in included files to prevent direct access.
+ * define() is used in the installation folder rather than "const" to not error for PHP 5.2 and lower
+ */
+define('_JEXEC', 1);
+
+// Load the administrator application's path constants
+if (file_exists(__DIR__ . '/defines.php'))
+{
+	include_once __DIR__ . '/defines.php';
+}
+
+if (!defined('_JDEFINES'))
+{
+	define('JPATH_BASE', __DIR__);
+	require_once JPATH_BASE . '/includes/defines.php';
+}
+
+require_once JPATH_BASE . '/includes/framework.php';
+require_once JPATH_BASE . '/includes/helper.php';
+require_once JPATH_BASE . '/includes/toolbar.php';
+
+// Boot JApplicationAdministrator so the application references in the factory resolve correctly.
+JFactory::getApplication('administrator');
+
+// Set the component path (un)constants
+define('JPATH_COMPONENT', JPATH_ADMINISTRATOR . '/components/com_joomlaupdate');
+define('JPATH_COMPONENT_ADMINISTRATOR', JPATH_ADMINISTRATOR . '/components/com_joomlaupdate');
+define('JPATH_COMPONENT_SITE', JPATH_SITE . '/components/com_joomlaupdate');
+
+// Load the update component's model to run the cleanup methods
+JModelLegacy::addIncludePath(JPATH_COMPONENT_ADMINISTRATOR . '/models', 'JoomlaupdateModel');
+
+/** @var JoomlaupdateModelDefault $model */
+$model = JModelLegacy::getInstance('default', 'JoomlaupdateModel');
+
+// Make sure we got the model
+if (!($model instanceof JoomlaupdateModelDefault))
+{
+	echo 'Could not load update component model, please check the logs for additional details.' . PHP_EOL;
+
+	exit(1);
+}
+
+// Load up the logger
+JLog::addLogger(
+	array(
+		'format'    => '{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}',
+		'text_file' => 'joomla_update.php',
+	),
+	JLog::INFO,
+	array('Update', 'databasequery', 'jerror')
+);
+
+JLog::add('Starting manual update using postupdate', JLog::INFO, 'Update');
+
+// Load the Joomla library and update component language files
+JFactory::getLanguage()->load('lib_joomla');
+JFactory::getLanguage()->load('com_joomlaupdate');
+
+JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_FINALISE'), JLog::INFO, 'Update');
+
+// Finalize the update
+if ($model->finaliseUpgrade() === false)
+{
+	echo 'Failed to finalize the upgrade, please check the logs for additional details.' . PHP_EOL;
+
+	exit(1);
+}
+
+JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_CLEANUP'), JLog::INFO, 'Update');
+
+// Cleanup after the update
+$model->cleanUp();
+
+JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_COMPLETE', JVERSION), JLog::INFO, 'Update');
+JLog::add('Finished manual update using postupdate', JLog::INFO, 'Update');
+
+echo 'Update to ' . JVERSION . ' completed successfully.' . PHP_EOL;

--- a/update.php
+++ b/update.php
@@ -100,6 +100,7 @@ foreach ($phpVersions as $phpVersion)
 		// To make management easier, we use these files for all variants
 		copy(__DIR__ . '/docker-entrypoint.sh', __DIR__ . "/$phpVersion/$platform/docker-entrypoint.sh");
 		copy(__DIR__ . '/makedb.php', __DIR__ . "/$phpVersion/$platform/makedb.php");
+		copy(__DIR__ . '/postupdate.php', __DIR__ . "/$phpVersion/$platform/postupdate.php");
 	}
 }
 


### PR DESCRIPTION
Using the web updater in a Docker-based installation can be somewhat problematic.
It does not support automated deploys very well, also the container or a docker-compose-yml file can become somewhat out-of-date if it is still configured to a fixed, older version than the one currently running on the server.

This PR adds the ability to this Docker Image to perform an auto-upgrade:

If an existing Joomla installation in the /var/www/html volume is found, compare installed Joomla version with the one in this Docker Image and run an upgrade if Minor- and/or Patch-Version are newer.

This is done by overwriting the existing Joomla Core files in the volume with the newly downloaded ones from the Docker Image, running the "Post-Manual Update Script" from https://gist.github.com/mbabker/d7bfb4e1e2fbc6b7815a733607f89281 afterwards (as suggested [here](https://github.com/joomla/docker-joomla/issues/17#issuecomment-324490528) in #17) and removing the 'installation' directory again.