### PR TITLE
sendmail ( or msmtp)

### DIFF
--- a/php7.2/apache/Dockerfile
+++ b/php7.2/apache/Dockerfile
@@ -20,6 +20,7 @@ RUN set -ex; \
 		libmemcached-dev \
 		libpng-dev \
 		libpq-dev \
+		sendmail \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \


### PR DESCRIPTION
Newly created containers can't send email out-of-the-box. Add sendmail (or msmtp) to allow users to bind their own sendmail (or msmtp) configuration file.